### PR TITLE
do not always import tests in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ import site
 
 from pydivert.decorators import cd
 from pydivert.install import WinDivertInstaller
-from pydivert.tests import run_test_suites
 
 
 __author__ = 'fabio'
@@ -89,6 +88,8 @@ class RunTests(Command):
     extra_args = []
 
     def run(self):
+        from pydivert.tests import run_test_suites
+
         for env_name, env_value in self.extra_env.items():
             os.environ[env_name] = str(env_value)
 


### PR DESCRIPTION
Hi Fabio,

thanks for your great work here. We're using pydivert for mitmproxy's upcoming transparent mode on Windows and it works like a charm. However, the installation fails on a fresh Windows machine as setup.py imports pydivert.tests, which again tries to import mock, but mock isn't installed.

```
C:\Users\user\Downloads\pydivert-master>python setup.py install
Traceback (most recent call last):
  File "setup.py", line 22, in <module>
    from pydivert.tests import run_test_suites
  File "C:\Users\user\Downloads\pydivert-master\pydivert\tests\__init__.py", line 25, in <module>
    from mock import patch, MagicMock
ImportError: No module named mock
```

This PR moves the import call into `RunTests.run`.

You may also want to add a [extras_require](https://pythonhosted.org/setuptools/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies) to your setup.py, although anyone who runs tests will figure out how to install mock anyway.

Thanks for you work on pydivert!
Max
