### PR TITLE
Simplify Things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage
 dist/
 .cache/
 venv/
+.coverage

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ logs
 coverage
 *~
 .idea
+dist/
+.cache/
+venv/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include pydivert/windivert/*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+environment:
+  matrix:
+    - python: 27
+    - python: 27-x64
+    - python: 35
+    - python: 35-x64
+
+install:
+  - "SET PATH=C:\\Python%PYTHON%;c:\\Python%PYTHON%\\scripts;%PATH%"
+  - "python -m pip install --disable-pip-version-check -U pip"
+  - "pip install -e .[test]"
+
+build: false
+
+test_script:
+  - py.test pydivert --capture=no -v --cov pydivert
+  - python -u setup.py bdist_wheel
+  - ps: Get-ChildItem dist\*.whl | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,4 +15,5 @@ build: false
 test_script:
   - py.test pydivert --capture=no -v --cov pydivert
   - python -u setup.py bdist_wheel
+  - codecov
   - ps: Get-ChildItem dist\*.whl | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }

--- a/pydivert/enum.py
+++ b/pydivert/enum.py
@@ -40,12 +40,6 @@ HelperOption = enum(NO_IP_CHECKSUM=1,
                     NO_TCP_CHECKSUM=8,
                     NO_UDP_CHECKSUM=16)
 
-RegKeys = enum(VERSION10=r"SYSTEM\CurrentControlSet\Services\WinDivert1.0",
-               VERSION11=r"SYSTEM\CurrentControlSet\Services\WinDivert1.1")
-
-DriverVersions = enum(VERSION10=0,
-                      VERSION11=1)
-
 Defaults = enum(PACKET_BUFFER_SIZE=1500, )
 
 ErrorCodes = enum(ERROR_IO_PENDING=997)

--- a/pydivert/exception.py
+++ b/pydivert/exception.py
@@ -16,11 +16,6 @@
 __author__ = 'fabio'
 
 
-class DriverNotRegisteredException(Exception):
-    def __init__(self, message="Driver is not registered"):
-        super(DriverNotRegisteredException, self).__init__(self, message)
-
-
 class MethodUnsupportedException(Exception):
     def __init__(self, message="The method is not supported in this driver version"):
         super(MethodUnsupportedException, self).__init__(self, message)
@@ -29,8 +24,3 @@ class MethodUnsupportedException(Exception):
 class AsyncCallFailedException(Exception):
     def __init__(self, message="AsyncCall could not be run"):
         super(AsyncCallFailedException, self).__init__(self, message)
-
-
-class FutureConsumedException(Exception):
-    def __init__(self, message="The future called has no more data"):
-        super(FutureConsumedException, self).__init__(self, message)

--- a/pydivert/models.py
+++ b/pydivert/models.py
@@ -266,9 +266,8 @@ class HeaderWrapper(object):
     header, except the "Options" one.
     """
 
-    def __init__(self, hdr, opts='', encoding="UTF-8"):
+    def __init__(self, hdr, opts=''):
         self.hdr, self.opts = hdr, opts
-        self.encoding = encoding
 
         for name, clazz in headers_map.items():
             if isinstance(hdr, clazz):
@@ -301,7 +300,7 @@ class HeaderWrapper(object):
         return hexed
 
     def __repr__(self):
-        return self.raw.decode(self.encoding)
+        return self.raw.decode()
 
     def __str__(self):
         return "%s Header: %s [Options: %s]" % (self.type.title(),
@@ -338,7 +337,7 @@ class CapturedPacket(object):
     Gathers several network layers of data
     """
 
-    def __init__(self, headers, payload=None, raw_packet=None, meta=None, encoding="UTF-8"):
+    def __init__(self, headers, payload=None, raw_packet=None, meta=None):
         if len(headers) > 2:
             raise ValueError("No more than 2 headers (tcp/udp/icmp over ip) are supported")
 
@@ -353,7 +352,6 @@ class CapturedPacket(object):
                 self.headers[0] = header
             else:
                 self.headers[1] = header
-        self.encoding = encoding
 
     def _get_from_headers(self, key):
         for header in self.headers:
@@ -433,21 +431,21 @@ class CapturedPacket(object):
     def src_addr(self):
         header, src_addr = self._get_from_headers("SrcAddr")
         if src_addr:
-            return addr_to_string(self.address_family, src_addr, self.encoding)
+            return addr_to_string(self.address_family, src_addr)
 
     @src_addr.setter
     def src_addr(self, value):
-        self._set_in_headers("SrcAddr", string_to_addr(self.address_family, value, self.encoding))
+        self._set_in_headers("SrcAddr", string_to_addr(self.address_family, value))
 
     @property
     def dst_addr(self):
         header, dst_addr = self._get_from_headers("DstAddr")
         if dst_addr:
-            return addr_to_string(self.address_family, dst_addr, self.encoding)
+            return addr_to_string(self.address_family, dst_addr)
 
     @dst_addr.setter
     def dst_addr(self, value):
-        self._set_in_headers("DstAddr", string_to_addr(self.address_family, value, self.encoding))
+        self._set_in_headers("DstAddr", string_to_addr(self.address_family, value))
 
     def __getattr__(self, item):
         clazz = headers_map.get(item, None)
@@ -476,7 +474,7 @@ class CapturedPacket(object):
         return unhexlify(hexed)
 
     def __repr__(self):
-        return hexlify(self.raw).decode(self.encoding)
+        return hexlify(self.raw).decode()
 
     def __str__(self):
         tokens = list()

--- a/pydivert/tests/__init__.py
+++ b/pydivert/tests/__init__.py
@@ -14,36 +14,15 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#SocketServer has been renamed in python3 to socketserver
-from contextlib import contextmanager
-import os
 import socket
-import subprocess
-import sys
-
-from mock import patch, MagicMock
-
 
 try:
+    # SocketServer has been renamed in python3 to socketserver
     from socketserver import ThreadingMixIn, TCPServer, UDPServer, BaseRequestHandler
 except ImportError:
     from SocketServer import ThreadingMixIn, TCPServer, UDPServer, BaseRequestHandler
 
 __author__ = 'fabio'
-
-
-@contextmanager
-def hush(fd):
-    """
-    A context manager to redirect to devnull all the writes to the given file descriptor
-    """
-    old_fd = getattr(sys, fd)
-    try:
-        magic_mock = MagicMock()
-        magic_mock.write = lambda *args, **kwargs: None
-        setattr(sys, fd, magic_mock)
-    finally:
-        setattr(sys, fd, old_fd)
 
 
 class EchoUpperTCPHandler(BaseRequestHandler):
@@ -75,7 +54,7 @@ class EchoUpperUDPHandler(BaseRequestHandler):
 class FakeTCPServerIPv4(ThreadingMixIn, TCPServer):
     allow_reuse_address = True
 
-    def __str__(self):
+    def __str__(self):  # pragma: no cover
         return "FakeTCPServerIPv4 listening on %s" % self.server_address
 
 
@@ -83,14 +62,14 @@ class FakeTCPServerIPv6(ThreadingMixIn, TCPServer):
     allow_reuse_address = True
     address_family = socket.AF_INET6
 
-    def __str__(self):
+    def __str__(self):  # pragma: no cover
         return "FakeTCPServerIPv6 listening on %s" % self.server_address
 
 
 class FakeUDPServer(ThreadingMixIn, UDPServer):
     allow_reuse_address = True
 
-    def __str__(self):
+    def __str__(self):  # pragma: no cover
         return "FakeUDPServer listening on %s" % self.server_address
 
 
@@ -138,17 +117,3 @@ def random_free_port(family=socket.AF_INET, type=socket.SOCK_STREAM):
         return s.getsockname()[1]
     finally:
         s.close()
-
-
-def prepare_env(versions=None):
-    """
-    Prepares the environment by stopping and deleting services
-    """
-    print("Preparing test environment for WinDivert.")
-    if not versions:
-        versions = ("1.0", "1.1")
-    for version in versions:
-        with open(os.devnull, 'wb') as devnull:
-            sys.stdout.write("Stopping version %s\n" % version)
-            subprocess.call(['sc', 'stop', 'WinDivert%s' % version], stdout=devnull, stderr=devnull)
-            subprocess.call(['sc', 'delete', 'WinDivert%s' % version], stdout=devnull, stderr=devnull)

--- a/pydivert/tests/__init__.py
+++ b/pydivert/tests/__init__.py
@@ -152,24 +152,3 @@ def prepare_env(versions=None):
             sys.stdout.write("Stopping version %s\n" % version)
             subprocess.call(['sc', 'stop', 'WinDivert%s' % version], stdout=devnull, stderr=devnull)
             subprocess.call(['sc', 'delete', 'WinDivert%s' % version], stdout=devnull, stderr=devnull)
-
-
-def run_test_suites():
-    import unittest
-    from unittest.test import loader
-    from pydivert.tests import test_winutils, test_windivert, test_models
-
-    runner = unittest.TextTestRunner()
-    suite = unittest.TestSuite()
-    dll_path = os.path.join(os.path.join(sys.exec_prefix, "DLLs", "WinDivert.dll"))
-
-    if os.path.exists(dll_path):
-        sys.stdout.write("Found WinDivert.dll in python DLLs directory. Testing against it...\n")
-        prepare_env()
-        suite.addTests(loader.loadTestsFromModule(test_windivert))
-
-    suite.addTests(loader.loadTestsFromModule(test_winutils))
-    suite.addTests(loader.loadTestsFromModule(test_models))
-    runner.run(suite)
-
-

--- a/pydivert/tests/test_windivert.py
+++ b/pydivert/tests/test_windivert.py
@@ -15,18 +15,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from binascii import hexlify
 import socket
-import struct
 import threading
 import unittest
 import os
-import sys
 
 from pydivert.enum import Param, Defaults
-from pydivert.exception import MethodUnsupportedException
-from pydivert.winutils import inet_pton, inet_ntop
 from pydivert.tests import FakeTCPServerIPv4, EchoUpperTCPHandler, FakeTCPClient, random_free_port, FakeUDPServer, \
     EchoUpperUDPHandler, FakeUDPClient, FakeTCPServerIPv6
-from pydivert.windivert import Handle, WinDivert
+from pydivert.windivert import Handle, WinDivert, DEFAULT_DLL_PATH
 
 
 __author__ = 'fabio'
@@ -37,10 +33,6 @@ class BaseTestCase(unittest.TestCase):
     A base test case to take driver version into account.
     Tests the basic operations like registering the driver.
     """
-    driver_dir = os.path.join(os.path.join(sys.exec_prefix, "DLLs"))
-
-    def setUp(self):
-        self.dll_path = os.path.join(self.driver_dir, "WinDivert.dll")
 
     def tearDown(self):
         pass
@@ -49,20 +41,17 @@ class BaseTestCase(unittest.TestCase):
         """
         Tests DLL registration
         """
-        d = WinDivert(self.dll_path).register()
-        self.assertTrue(d.is_registered())
-        self.assertEquals(os.path.abspath(d.dll_path),
-                          os.path.abspath(self.dll_path))
+        d = WinDivert().register()
+        assert d.is_registered()
+        assert os.path.abspath(d.dll_path) == DEFAULT_DLL_PATH
 
     def test_load_ok(self):
         """
         Tests DLL loading with a correct path
         """
         try:
-            print(self.dll_path)
-            d = WinDivert(self.dll_path)
-            self.assertEquals(os.path.abspath(d.get_reference()._name),
-                              os.path.abspath(self.dll_path))
+            d = WinDivert()
+            assert os.path.abspath(d.get_reference()._name) == DEFAULT_DLL_PATH
         except WindowsError as e:
             self.fail("WinDivert() constructor raised %s" % e)
 
@@ -71,26 +60,26 @@ class BaseTestCase(unittest.TestCase):
         Tests the open_handle method.
         """
         # with cd(os.path.dirname(self.dll_path)):
-        handle = WinDivert(self.dll_path).open_handle(filter="tcp.DstPort == 23")
-        self.assertIsInstance(handle, Handle)
-        self.assertTrue(handle.is_opened)
+        handle = WinDivert().open_handle(filter="tcp.DstPort == 23")
+        assert isinstance(handle, Handle)
+        assert handle.is_opened
         handle.close()
-        self.assertFalse(handle.is_opened)
+        assert not handle.is_opened
 
     def test_load_invalid_path(self):
         """
         Tests DLL loading with an invalid path
         """
-        self.assertRaises(WindowsError, WinDivert, "invalid_path")
+        self.assertRaises(ValueError, WinDivert, "invalid_path")
 
 class WinDivertTestCase(BaseTestCase):
     """
-    Tests laoding from registry, opening handles and functions not requiring network traffic
+    Tests loading from registry, opening handles and functions not requiring network traffic
     """
 
     def setUp(self):
         super(WinDivertTestCase, self).setUp()
-        WinDivert(self.dll_path).register()
+        WinDivert().register()
         #self.dll_path = os.path.join(self.driver_dir, "WinDivert.dll")
 
 
@@ -110,16 +99,16 @@ class WinDivertTestCase(BaseTestCase):
         """
         driver = WinDivert()
         handle = Handle(driver, filter="tcp.DstPort == 23", priority=1000)
-        self.assertIsInstance(handle, Handle)
-        self.assertFalse(handle.is_opened)
+        assert isinstance(handle, Handle)
+        assert not handle.is_opened
 
     def test_implicit_construct_handle(self):
         """
         Tests constructing an handle without passing a WinDivert instance
         """
         handle = Handle(filter="tcp.DstPort == 23", priority=1000)
-        self.assertIsInstance(handle, Handle)
-        self.assertFalse(handle.is_opened)
+        assert isinstance(handle, Handle)
+        assert not handle.is_opened
 
     def test_handle_invalid(self):
         """
@@ -134,7 +123,7 @@ class WinDivertTestCase(BaseTestCase):
         Tests usage of an Handle as a context manager
         """
         with Handle(filter="tcp.DstPort == 23", priority=1000) as filter0:
-            self.assertNotEqual(str(filter0._handle), "-1")
+            assert str(filter0._handle) != "-1"
 
     def test_queue_time_range(self):
         """
@@ -144,10 +133,10 @@ class WinDivertTestCase(BaseTestCase):
         with Handle(filter="tcp.DstPort == 23", priority=1000) as filter0:
             #TODO: this range should have a proper default representation
 
-            def_range = (128, 512) if filter0.driver.is_legacy_driver() else (128, 512, 2048)
+            def_range = (128, 512, 2048)
             for value in def_range:
                 filter0.set_param(Param.QUEUE_TIME, value)
-                self.assertEqual(value, filter0.get_param(Param.QUEUE_TIME))
+                assert value == filter0.get_param(Param.QUEUE_TIME)
 
     def test_queue_len_range(self):
         """
@@ -158,38 +147,14 @@ class WinDivertTestCase(BaseTestCase):
             #TODO: this range should have a proper default representation
             for value in (1, 512, 8192):
                 filter0.set_param(Param.QUEUE_LEN, value)
-                self.assertEqual(value, filter0.get_param(Param.QUEUE_LEN))
-
-    def test_parse_ipv4_address(self):
-        """
-        Tests parsing of an ipv4 address into a network byte value
-        """
-        address = "192.168.1.1"
-        driver = WinDivert()
-        driver.register()
-        result = driver.parse_ipv4_address(address)
-        self.assertEqual(struct.unpack(">I", inet_pton(socket.AF_INET, address))[0], result)
-
-    def test_parse_ipv6_address(self):
-        """
-        Tests parsing of an ipv4 address into a network byte value
-        """
-        address = "2607:f0d0:1002:0051:0000:0000:0000:0004"
-        driver = WinDivert(self.dll_path).register()
-        result = inet_ntop(socket.AF_INET6, driver.parse_ipv6_address(address))
-        self.assertEqual(inet_pton(socket.AF_INET6, address),
-                         inet_pton(socket.AF_INET6, result))
+                assert value == filter0.get_param(Param.QUEUE_LEN)
 
     def test_parse_packet_raise_exc(self):
         """
         Tests the parsing packet function to raise an exception when invoked with wrong number of arguments
         """
-        driver = WinDivert(self.dll_path).register()
+        driver = WinDivert().register()
         self.assertRaises(ValueError, driver.parse_packet, "", "", "")
-
-
-    def tearDown(self):
-        super(WinDivertTestCase, self).tearDown()
 
 
 class WinDivertTCPDataCaptureTestCase(BaseTestCase):
@@ -202,7 +167,7 @@ class WinDivertTCPDataCaptureTestCase(BaseTestCase):
         # Initialize the fake tcp server
         self.server = FakeTCPServerIPv4(("127.0.0.1", 0), EchoUpperTCPHandler)
         filter = "outbound and tcp.DstPort == %d and tcp.PayloadLength > 0" % self.server.server_address[1]
-        self.driver = WinDivert(os.path.join(self.driver_dir, "WinDivert.dll"))
+        self.driver = WinDivert()
         self.driver.register()
 
         self.handle = self.driver.open_handle(filter=filter)
@@ -221,8 +186,8 @@ class WinDivertTCPDataCaptureTestCase(BaseTestCase):
         Tests if metadata is right
         """
         raw_packet, metadata = self.handle.recv()
-        self.assertTrue(metadata.is_outbound())
-        self.assertTrue(metadata.is_loopback())
+        assert metadata.is_outbound()
+        assert metadata.is_loopback()
 
     def test_pass_through_tuple(self):
         """
@@ -230,7 +195,7 @@ class WinDivertTCPDataCaptureTestCase(BaseTestCase):
         """
         self.handle.send(self.handle.recv())
         self.client_thread.join(timeout=10)
-        self.assertEqual(self.text.upper(), self.client.response.decode("UTF-8"))
+        assert self.text.upper() == self.client.response.decode()
 
     def test_pass_through_no_tuple(self):
         """
@@ -239,7 +204,7 @@ class WinDivertTCPDataCaptureTestCase(BaseTestCase):
         raw_packet, meta = self.handle.recv()
         self.handle.send(raw_packet, meta)
         self.client_thread.join(timeout=10)
-        self.assertEqual(self.text.upper(), self.client.response.decode("UTF-8"))
+        assert self.text.upper() == self.client.response.decode()
 
     def test_pass_through_packet(self):
         """
@@ -247,7 +212,7 @@ class WinDivertTCPDataCaptureTestCase(BaseTestCase):
         """
         self.handle.send(self.handle.receive())
         self.client_thread.join(timeout=10)
-        self.assertEqual(self.text.upper(), self.client.response.decode("UTF-8"))
+        assert self.text.upper() == self.client.response.decode()
 
     def test_parse_packet(self):
         """
@@ -255,9 +220,8 @@ class WinDivertTCPDataCaptureTestCase(BaseTestCase):
         """
         raw_packet, metadata = self.handle.recv()
         packet = self.driver.parse_packet(raw_packet)
-        self.assertEqual("{}:{}".format(packet.dst_addr, packet.dst_port),
-                         "{}:{}".format(*self.server.server_address))
-        self.assertEqual(self.text.encode("UTF-8"), packet.payload)
+        assert (packet.dst_addr, packet.dst_port) == self.server.server_address
+        assert self.text.encode() == packet.payload
 
     def test_parse_packet_meta(self):
         """
@@ -265,10 +229,9 @@ class WinDivertTCPDataCaptureTestCase(BaseTestCase):
         """
         raw_packet, metadata = self.handle.recv()
         packet = self.driver.parse_packet(raw_packet, metadata)
-        self.assertEqual("%s:%d" % (packet.dst_addr, packet.dst_port),
-                         "%s:%d" % self.server.server_address)
-        self.assertEqual(self.text.encode("UTF-8"), packet.payload)
-        self.assertEqual(packet.meta, metadata)
+        assert (packet.dst_addr, packet.dst_port) == self.server.server_address
+        assert self.text.encode() == packet.payload
+        assert packet.meta == metadata
 
     def test_dump_data(self):
         """
@@ -276,11 +239,10 @@ class WinDivertTCPDataCaptureTestCase(BaseTestCase):
         """
         raw_packet, metadata = self.handle.recv()
         packet = self.handle.driver.parse_packet(raw_packet)
-        self.assertEqual(raw_packet[len(packet.payload) * -1:],
-                         packet.raw[len(packet.payload) * -1:])
+        assert raw_packet[len(packet.payload) * -1:] == packet.raw[len(packet.payload) * -1:]
         self.handle.send((raw_packet, metadata))
         self.client_thread.join(timeout=10)
-        self.assertEqual(self.text.upper(), self.client.response.decode("UTF-8"))
+        assert self.text.upper() == self.client.response.decode()
 
     def test_raw_packet_from_captured(self):
         """
@@ -289,7 +251,7 @@ class WinDivertTCPDataCaptureTestCase(BaseTestCase):
         raw_packet1, metadata = self.handle.recv()
         packet = self.handle.driver.parse_packet(raw_packet1)
         raw_packet2 = packet.raw
-        self.assertEqual(hexlify(raw_packet1), hexlify(raw_packet2))
+        assert hexlify(raw_packet1) == hexlify(raw_packet2)
 
     def test_raw_packet_len(self):
         """
@@ -300,7 +262,7 @@ class WinDivertTCPDataCaptureTestCase(BaseTestCase):
         packet1.dst_port = 80
         packet1.dst_addr = "10.10.10.10"
         raw_packet2 = packet1.raw
-        self.assertEqual(len(raw_packet1), len(raw_packet2))
+        assert len(raw_packet1) == len(raw_packet2)
 
     def test_packet_checksum(self):
         """
@@ -308,7 +270,7 @@ class WinDivertTCPDataCaptureTestCase(BaseTestCase):
         """
         raw_packet1, metadata = self.handle.recv()
         raw_packet2 = self.handle.driver.calc_checksums(raw_packet1)
-        self.assertEqual(hexlify(raw_packet1), hexlify(raw_packet2))
+        assert hexlify(raw_packet1) == hexlify(raw_packet2)
 
     def test_packet_checksum_recalc(self):
         """
@@ -319,7 +281,7 @@ class WinDivertTCPDataCaptureTestCase(BaseTestCase):
         packet.dst_port = 80
         packet.dst_addr = "10.10.10.10"
         raw_packet2 = self.handle.driver.calc_checksums(packet.raw)
-        self.assertNotEqual(hexlify(raw_packet1), hexlify(raw_packet2))
+        assert hexlify(raw_packet1) != hexlify(raw_packet2)
 
     def test_packet_reconstruct_checksummed(self):
         """
@@ -331,19 +293,19 @@ class WinDivertTCPDataCaptureTestCase(BaseTestCase):
         packet1.dst_addr = "10.10.10.10"
         raw_packet2 = self.handle.driver.calc_checksums(packet1.raw)
         packet2 = self.handle.driver.parse_packet(raw_packet2)
-        self.assertEqual(packet1.dst_port, packet2.dst_port)
-        self.assertEqual(packet1.dst_addr, packet2.dst_addr)
-        self.assertNotEqual(hexlify(raw_packet1), hexlify(raw_packet2))
-        self.assertEqual(len(raw_packet1), len(packet2.raw))
+        assert packet1.dst_port == packet2.dst_port
+        assert packet1.dst_addr == packet2.dst_addr
+        assert hexlify(raw_packet1) != hexlify(raw_packet2)
+        assert len(raw_packet1) == len(packet2.raw)
 
     def test_packet_to_string(self):
         """
         Tests string conversions
         """
         packet = self.handle.receive()
-        self.assertIn(str(packet.tcp_hdr), str(packet))
-        self.assertIn(str(packet.ipv4_hdr), str(packet))
-        self.assertEqual(packet.tcp_hdr.raw.decode("UTF-8"), repr(packet.tcp_hdr))
+        assert str(packet.tcp_hdr)in str(packet)
+        assert str(packet.ipv4_hdr) in str(packet)
+        assert packet.tcp_hdr.raw.decode() == repr(packet.tcp_hdr)
         self.handle.send(packet)
 
     def test_packet_repr(self):
@@ -351,7 +313,7 @@ class WinDivertTCPDataCaptureTestCase(BaseTestCase):
         Tests repr conversion
         """
         packet = self.handle.receive()
-        self.assertEqual(repr(packet), hexlify(packet.raw).decode("UTF-8"))
+        assert repr(packet) == hexlify(packet.raw).decode()
         self.handle.send(packet)
 
     def test_modify_address(self):
@@ -361,9 +323,9 @@ class WinDivertTCPDataCaptureTestCase(BaseTestCase):
         packet = self.handle.receive()
         current = packet.ipv4_hdr.DstAddr
         packet.dst_addr = "10.0.2.15"
-        self.assertEqual(packet.ipv4_hdr.DstAddr, 251789322)
+        assert packet.ipv4_hdr.DstAddr == 251789322
         packet.ipv4_hdr.DstAddr = current
-        self.assertEqual(packet.dst_addr, "127.0.0.1")
+        assert packet.dst_addr == "127.0.0.1"
         self.handle.send(packet)
 
     def test_modify_port(self):
@@ -373,9 +335,9 @@ class WinDivertTCPDataCaptureTestCase(BaseTestCase):
         packet = self.handle.receive()
         current = packet.tcp_hdr.DstPort
         packet.dst_port = 23
-        self.assertEqual(packet.tcp_hdr.DstPort, 5888)
+        assert packet.tcp_hdr.DstPort == 5888
         packet.tcp_hdr.DstPort = current
-        self.assertEqual(packet.dst_port, self.server.server_address[1])
+        assert packet.dst_port == self.server.server_address[1]
         self.handle.send(packet)
 
     def test_send_wrong_args(self):
@@ -405,7 +367,7 @@ class WinDivertTCPIPv4TestCase(BaseTestCase):
         # Initialize the fake tcp server
         self.server = FakeTCPServerIPv4(("127.0.0.1", 0),
                                         EchoUpperTCPHandler)
-        self.driver = WinDivert(os.path.join(self.driver_dir, "WinDivert.dll"))
+        self.driver = WinDivert()
 
         self.server_thread = threading.Thread(target=self.server.serve_forever)
         self.server_thread.start()
@@ -421,8 +383,8 @@ class WinDivertTCPIPv4TestCase(BaseTestCase):
         with Handle(filter="tcp.DstPort == %d" % self.server.server_address[1]) as handle:
             client_thread.start()
             packet = handle.receive()
-            self.assertEqual(packet.tcp_hdr.Syn, 1)
-            self.assertEqual(hexlify(packet.tcp_hdr.Options), b"0204ffd70103030801010402")
+            assert packet.tcp_hdr.Syn == 1
+            assert hexlify(packet.tcp_hdr.Options) == b"0204ffd70103030801010402"
         client_thread.join(timeout=10)
 
     def test_modify_tcp_payload(self):
@@ -443,13 +405,13 @@ class WinDivertTCPIPv4TestCase(BaseTestCase):
 
             if metadata.is_outbound():
                 packet = handle.driver.parse_packet(raw_packet)
-                self.assertEqual(text.encode("UTF-8"), packet.payload)
+                assert text.encode("UTF-8") == packet.payload
                 packet.payload = new_text.encode("UTF-8")
                 raw_packet = packet.raw
 
             handle.send((raw_packet, metadata))
             client_thread.join(timeout=10)
-            self.assertEqual(new_text.upper(), client.response.decode("UTF-8"))
+            assert new_text.upper() == client.response.decode()
 
     def test_modify_tcp_header(self):
         """
@@ -480,7 +442,7 @@ class WinDivertTCPIPv4TestCase(BaseTestCase):
                 if hasattr(client, "response") and client.response:
                     break
             client_thread.join(timeout=10)
-            self.assertEqual(text.upper(), client.response.decode("UTF-8"))
+            assert text.upper() == client.response.decode()
 
     def test_modify_tcp_header_shortcut(self):
         """
@@ -509,15 +471,15 @@ class WinDivertTCPIPv4TestCase(BaseTestCase):
                 if hasattr(client, "response") and client.response:
                     break
             client_thread.join(timeout=10)
-            self.assertEqual(text.upper(), client.response.decode("UTF-8"))
+            assert text.upper() == client.response.decode()
 
     def test_pass_through_mtu_size(self):
         """
         Tests sending a packet bigger than mtu
         """
         srv_port = self.server.server_address[1]
-        text = "#" * (Defaults.PACKET_BUFFER_SIZE + 1)
-        client = FakeTCPClient(("127.0.0.1", srv_port), text.encode("UTF-8"))
+        text = b"#" * (Defaults.PACKET_BUFFER_SIZE + 1)
+        client = FakeTCPClient(("127.0.0.1", srv_port), text)
         client_thread = threading.Thread(target=client.send)
 
         f = "tcp.DstPort == {0} or tcp.SrcPort == {0} and tcp.PayloadLength > 0".format(srv_port)
@@ -529,7 +491,7 @@ class WinDivertTCPIPv4TestCase(BaseTestCase):
                 if hasattr(client, "response") and client.response:
                     break
             client_thread.join(timeout=10)
-            self.assertEqual(text.upper(), client.response.decode("UTF-8"))
+            assert text == client.response
 
     def tearDown(self):
         self.server.shutdown()
@@ -546,7 +508,7 @@ class WinDivertTCPIPv6TestCase(BaseTestCase):
         super(WinDivertTCPIPv6TestCase, self).setUp()
         # Initialize the fake tcp server
         self.server = FakeTCPServerIPv6(("::1", 0), EchoUpperTCPHandler)
-        WinDivert(os.path.join(self.driver_dir, "WinDivert.dll")).register()
+        WinDivert().register()
 
         self.server_thread = threading.Thread(target=self.server.serve_forever)
         self.server_thread.start()
@@ -562,8 +524,8 @@ class WinDivertTCPIPv6TestCase(BaseTestCase):
         with Handle(filter="tcp.DstPort == %d" % self.server.server_address[1]) as handle:
             client_thread.start()
             packet = handle.receive()
-            self.assertEqual(packet.tcp_hdr.Syn, 1)
-            self.assertEqual(hexlify(packet.tcp_hdr.Options), b"0204ffc30103030801010402")
+            assert packet.tcp_hdr.Syn == 1
+            assert hexlify(packet.tcp_hdr.Options) == b"0204ffc30103030801010402"
 
     def test_pass_through(self):
         """
@@ -579,7 +541,7 @@ class WinDivertTCPIPv6TestCase(BaseTestCase):
             handle.send(handle.receive())
 
         client_thread.join(timeout=10)
-        self.assertEqual(text.upper(), client.response.decode("UTF-8"))
+        assert text.upper() == client.response.decode()
 
     def test_modify_tcp_payload(self):
         """
@@ -597,13 +559,13 @@ class WinDivertTCPIPv6TestCase(BaseTestCase):
 
             if metadata.is_outbound():
                 packet = handle.driver.parse_packet(raw_packet)
-                self.assertEqual(text.encode("UTF-8"), packet.payload)
+                assert text.encode("UTF-8") == packet.payload
                 packet.payload = new_text.encode("UTF-8")
                 raw_packet = packet.raw
 
             handle.send((raw_packet, metadata))
             client_thread.join(timeout=10)
-            self.assertEqual(new_text.upper(), client.response.decode("UTF-8"))
+            assert new_text.upper() == client.response.decode()
 
     # def test_modify_tcp_header(self):
     #     """
@@ -634,7 +596,7 @@ class WinDivertTCPIPv6TestCase(BaseTestCase):
     #             if hasattr(client, "response") and client.response:
     #                 break
     #         client_thread.join(timeout=10)
-    #         self.assertEqual(text.upper(), client.response)
+    #         assert text.upper() == client.response
 
     def tearDown(self):
         self.server.shutdown()
@@ -647,7 +609,7 @@ class WinDivertUDPTestCase(BaseTestCase):
         super(WinDivertUDPTestCase, self).setUp()
         # Initialize the fake tcp server
         self.server = FakeUDPServer(("127.0.0.1", 0), EchoUpperUDPHandler)
-        self.driver = WinDivert(os.path.join(self.driver_dir, "WinDivert.dll"))
+        self.driver = WinDivert()
 
         self.server_thread = threading.Thread(target=self.server.serve_forever)
         self.server_thread.start()
@@ -664,11 +626,11 @@ class WinDivertUDPTestCase(BaseTestCase):
             client_thread.start()
 
             packet = handle.receive()
-            self.assertEqual(text.encode("UTF-8"), packet.payload)
+            assert text.encode("UTF-8") == packet.payload
             handle.send(packet)
 
             client_thread.join(timeout=10)
-            self.assertEqual(text.upper(), client.response.decode("UTF-8"))
+            assert text.upper() == client.response.decode()
 
     def test_modify_udp_header(self):
         """
@@ -696,7 +658,7 @@ class WinDivertUDPTestCase(BaseTestCase):
                 handle.send(packet)
 
             client_thread.join(timeout=10)
-            self.assertEqual(text.upper(), client.response.decode("UTF-8"))
+            assert text.upper() == client.response.decode()
 
     def tearDown(self):
         self.server.shutdown()
@@ -710,7 +672,7 @@ class WinDivertExternalInterfaceTestCase(BaseTestCase):
         # Initialize the fake tcp server
         self.server = FakeTCPServerIPv4((socket.gethostbyname(socket.gethostname()), 0),
                                         EchoUpperTCPHandler)
-        WinDivert(os.path.join(self.driver_dir, "WinDivert.dll")).register()
+        WinDivert().register()
 
         self.server_thread = threading.Thread(target=self.server.serve_forever)
         self.server_thread.start()
@@ -723,8 +685,8 @@ class WinDivertExternalInterfaceTestCase(BaseTestCase):
         fake_addr = "10.10.10.10"
         srv_port = self.server.server_address[1]
         srv_addr = self.server.server_address[0]
-        text = "Hello World!"
-        client = FakeTCPClient((fake_addr, fake_port), text.encode("UTF-8"))
+        text = b"Hello World!"
+        client = FakeTCPClient((fake_addr, fake_port), text)
         client_thread = threading.Thread(target=client.send)
 
         f = "tcp.DstPort == %d or tcp.SrcPort == %d" % (fake_port, srv_port)
@@ -746,7 +708,7 @@ class WinDivertExternalInterfaceTestCase(BaseTestCase):
                 if hasattr(client, "response") and client.response:
                     break
             client_thread.join(timeout=10)
-            self.assertEqual(text.upper(), client.response.decode("UTF-8"))
+            assert text.upper() == client.response
 
     def tearDown(self):
         self.server.shutdown()
@@ -760,7 +722,7 @@ class WinDivertAsyncTestCase(BaseTestCase):
         # Initialize the fake tcp server
         self.server = FakeTCPServerIPv4(("127.0.0.1", 0), EchoUpperTCPHandler)
         filter = "outbound and tcp.DstPort == %d and tcp.PayloadLength > 0" % self.server.server_address[1]
-        self.driver = WinDivert(os.path.join(self.driver_dir, "WinDivert.dll"))
+        self.driver = WinDivert()
         self.driver.register()
 
         self.handle = self.driver.open_handle(filter=filter)
@@ -783,16 +745,13 @@ class WinDivertAsyncTestCase(BaseTestCase):
         def callback(*args):
             self.handle._send_async(*args)
 
-        if not self.handle.driver.is_legacy_driver():
-            for future in self.handle._receive_async(callback=callback):
-                if not future.is_complete():
-                    pass
-                else:
-                    break
-            self.client_thread.join(timeout=10)
-            self.assertEqual(self.text.upper(), self.client.response.decode("UTF-8"))
-        else:
-            self.assertRaises(MethodUnsupportedException, self.handle._receive_async, callback=callback)
+        for future in self.handle._receive_async(callback=callback):
+            if not future.is_complete():
+                pass
+            else:
+                break
+        self.client_thread.join(timeout=10)
+        assert self.text.upper() == self.client.response.decode()
 
     def tearDown(self):
         try:

--- a/pydivert/tests/test_winutils.py
+++ b/pydivert/tests/test_winutils.py
@@ -16,8 +16,8 @@
 import socket
 import unittest
 
+import pytest
 from pydivert.winutils import addr_to_string, string_to_addr
-
 
 __author__ = 'fabio'
 
@@ -30,7 +30,7 @@ class WinInetTestCase(unittest.TestCase):
         """
         address = "127.0.0.1"
         addr_fam = socket.AF_INET
-        self.assertEqual(address, addr_to_string(addr_fam, string_to_addr(addr_fam, address)))
+        assert address == addr_to_string(addr_fam, string_to_addr(addr_fam, address))
 
     def test_ipv6_loopback_conversion(self):
         """
@@ -39,7 +39,7 @@ class WinInetTestCase(unittest.TestCase):
         address = "::1"
         addr_fam = socket.AF_INET6
         ipv6 = addr_to_string(addr_fam, string_to_addr(addr_fam, address))
-        self.assertIn(ipv6, "::1")
+        assert ipv6 in "::1"
 
     def test_ipv4_address_conversion(self):
         """
@@ -47,7 +47,7 @@ class WinInetTestCase(unittest.TestCase):
         """
         address = "192.168.1.1"
         addr_fam = socket.AF_INET
-        self.assertEqual(address, addr_to_string(addr_fam, string_to_addr(addr_fam, address)))
+        assert address == addr_to_string(addr_fam, string_to_addr(addr_fam, address))
 
     def test_ipv6_address_conversion(self):
         """
@@ -56,7 +56,7 @@ class WinInetTestCase(unittest.TestCase):
         address = "2607:f0d0:1002:0051:0000:0000:0000:0004"
         addr_fam = socket.AF_INET6
         ipv6 = addr_to_string(addr_fam, string_to_addr(addr_fam, address))
-        self.assertIn(ipv6, (address, "2607:f0d0:1002:51::4"))
+        assert ipv6 in (address, "2607:f0d0:1002:51::4")
 
     def test_ipv4_wrong_address_family(self):
         """
@@ -64,9 +64,11 @@ class WinInetTestCase(unittest.TestCase):
         """
         address = "192.168.1.1"
         addr_fam = -1
-        self.assertRaises(ValueError, string_to_addr, addr_fam, address)
+        with pytest.raises(ValueError):
+            string_to_addr(addr_fam, address)
         addr = string_to_addr(socket.AF_INET, address)
-        self.assertRaises(ValueError, addr_to_string, addr_fam, (addr,))
+        with pytest.raises(ValueError):
+            addr_to_string(addr_fam, (addr,))
 
     def test_ipv6_wrong_address_family(self):
         """
@@ -74,6 +76,8 @@ class WinInetTestCase(unittest.TestCase):
         """
         address = "2607:f0d0:1002:0051:0000:0000:0000:0004"
         addr_fam = -1
-        self.assertRaises(ValueError, string_to_addr, addr_fam, address)
+        with pytest.raises(ValueError):
+            string_to_addr(addr_fam, address)
         addr = string_to_addr(socket.AF_INET6, address)
-        self.assertRaises(ValueError, addr_to_string, addr_fam, addr)
+        with pytest.raises(ValueError):
+            addr_to_string(addr_fam, addr)

--- a/pydivert/winutils.py
+++ b/pydivert/winutils.py
@@ -13,159 +13,46 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-# Original credits for the convertion functions pton e ntop to
-# https://gist.github.com/nnemkin/4966028
-# Native inet_pton and inet_ntop implementation for Python on Windows (with ctypes).
-from _ctypes import sizeof, FormatError, byref, POINTER
-from ctypes import Structure, Union, c_short, c_byte, c_ushort, c_ulong, windll, c_int, string_at, create_string_buffer
-from ctypes import memmove, c_void_p, c_char_p
-from ctypes.wintypes import DWORD, ULONG, HANDLE, BOOL
+
 import logging
 import socket
 import struct
-# _winreg has been renamed in python3 to winreg
-import errno
-from pydivert.exception import DriverNotRegisteredException
 
 try:
-    import winreg
+    import win_inet_pton
 except ImportError:
-    import _winreg as winreg
+    pass
+from _ctypes import POINTER
+from ctypes import Structure, Union, windll
+from ctypes import c_void_p, c_char_p
+from ctypes.wintypes import DWORD, ULONG, HANDLE, BOOL
 
 __author__ = 'fabio'
 logger = logging.getLogger(__name__)
 
 
-def string_to_addr(address_family, value, encoding="UTF-8"):
+def string_to_addr(address_family, value):
     """
     Convert a ip string in dotted form into a packed, binary format
     """
     if address_family == socket.AF_INET:
-        return struct.unpack("<I", inet_pton(socket.AF_INET, value, encoding))[0]
+        return struct.unpack("<I", socket.inet_pton(socket.AF_INET, value))[0]
     elif address_family == socket.AF_INET6:
-        return struct.unpack("<IIII", inet_pton(socket.AF_INET6, value, encoding))
+        return struct.unpack("<IIII", socket.inet_pton(socket.AF_INET6, value))
     else:
         raise ValueError("Unknown address_family: %s" % address_family)
 
 
-def addr_to_string(address_family, value, encoding="UTF-8"):
+def addr_to_string(address_family, value):
     """
     Convert a packed, binary format into a ip string in dotted form
     """
     if address_family == socket.AF_INET:
-        return inet_ntop(socket.AF_INET, struct.pack("<I", value), encoding)
+        return socket.inet_ntop(socket.AF_INET, struct.pack("<I", value))
     elif address_family == socket.AF_INET6:
-        return inet_ntop(socket.AF_INET6, struct.pack("<IIII", *value), encoding)
+        return socket.inet_ntop(socket.AF_INET6, struct.pack("<IIII", *value))
     else:
         raise ValueError("Unknown address_family: %s" % address_family)
-
-
-class sockaddr(Structure):
-    _fields_ = [("sa_family", c_short),
-                ("__pad1", c_ushort),
-                ("ipv4_addr", c_byte * 4),
-                ("ipv6_addr", c_byte * 16),
-                ("__pad2", c_ulong)]
-
-
-WSAStringToAddressA = windll.ws2_32.WSAStringToAddressA
-WSAAddressToStringA = windll.ws2_32.WSAAddressToStringA
-
-
-def inet_pton(address_family, ip_string, encoding="UTF-8"):
-    addr = sockaddr()
-    addr.sa_family = address_family
-    addr_size = c_int(sizeof(addr))
-
-    if WSAStringToAddressA(ip_string.encode(encoding),
-                           address_family,
-                           None,
-                           byref(addr),
-                           byref(addr_size)) != 0:
-        raise socket.error(FormatError())
-
-    if address_family == socket.AF_INET:
-        return string_at(addr.ipv4_addr, 4)
-    if address_family == socket.AF_INET6:
-        return string_at(addr.ipv6_addr, 16)
-
-    raise socket.error('unknown address family')
-
-
-def inet_ntop(address_family, packed_ip, encoding="UTF-8"):
-    addr = sockaddr()
-    addr.sa_family = address_family
-    addr_size = c_int(sizeof(addr))
-    ip_string = create_string_buffer(128)
-    ip_string_size = c_int(sizeof(addr))
-
-    if address_family == socket.AF_INET:
-        if len(packed_ip) != sizeof(addr.ipv4_addr):
-            raise socket.error('packed IP wrong length for inet_ntop')
-        memmove(addr.ipv4_addr, packed_ip, 4)
-    elif address_family == socket.AF_INET6:
-        if len(packed_ip) != sizeof(addr.ipv6_addr):
-            raise socket.error('packed IP wrong length for inet_ntop')
-        memmove(addr.ipv6_addr, packed_ip, 16)
-    else:
-        raise socket.error('unknown address family')
-
-    if WSAAddressToStringA(byref(addr),
-                           addr_size,
-                           None,
-                           ip_string,
-                           byref(ip_string_size)) != 0:
-        raise socket.error(FormatError())
-
-    return (ip_string[:ip_string_size.value - 1]).decode(encoding)
-
-
-def get_reg_values(key, root_key=winreg.HKEY_LOCAL_MACHINE):
-    """
-    Given a key name, return a dictionary of its values.
-    """
-    count = 0
-    result = {}
-    try:
-        logger.debug("Reading key %s" % key)
-        key_handle = winreg.OpenKey(root_key, key)
-    except WindowsError as error:
-        raise DriverNotRegisteredException()
-    try:
-        while True:
-            values = winreg.EnumValue(key_handle, count)
-            logger.debug("Found %s" % str(values))
-            count += 1
-            result.update({values[0]: values[1]})
-    except WindowsError as error:
-        if error.errno == errno.EINVAL:
-            if logger.isEnabledFor(logging.DEBUG):
-                logger.debug("Returning %d values" % len(result))
-            return result
-        else:
-            logger.error(error)
-            raise error
-    finally:
-        if key_handle:
-            logger.debug("Closing key handle for key %s" % key)
-            key_handle.Close()
-
-
-def del_reg_key(sub_key, key, root_key=winreg.HKEY_LOCAL_MACHINE):
-    """
-    Given a key name, removes it from the Windows registry
-    """
-    logger.debug("Removing key %s" % key)
-    try:
-        key_handle = winreg.OpenKey(root_key, sub_key, 0, winreg.KEY_ALL_ACCESS)
-        winreg.DeleteValue(key_handle, key)
-    except WindowsError as e:
-        if e.errno != errno.ENOENT:
-            logger.error("Got error while deleting key %s: %s" % (key, e))
-    else:
-        logger.debug("Closing key handle for key %s" % key)
-        key_handle.Close()
 
 
 class _US(Structure):
@@ -188,9 +75,7 @@ class OVERLAPPED(Structure):
     _fields_ = [
         ("Internal", POINTER(ULONG)),
         ("InternalHigh", POINTER(ULONG)),
-
         ("u", _U),
-
         ("hEvent", HANDLE),
     ]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
 [metadata]
 description-file = README.md
 license-file = LICENSE
+
+[bdist_wheel]
+universal=1

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,7 @@ license-file = LICENSE
 
 [bdist_wheel]
 universal=1
+
+[tool:pytest]
+testpaths = pydivert
+addopts = --capture=no --color=yes

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,9 @@ setup(
         "test": [
             "mock>=1.0.1",
             "pytest>=3.0.3",
+            "pytest-cov>=2.2.1",
+            "pytest-timeout>=1.0.0, <2",
+            "pytest-faulthandler>=1.3.0, <2",
             "wheel>=0.29",
         ],
         # Do not use a range operator here: https://bitbucket.org/pypa/setuptools/issues/380

--- a/setup.py
+++ b/setup.py
@@ -68,11 +68,8 @@ setup(
         ],
         # Do not use a range operator here: https://bitbucket.org/pypa/setuptools/issues/380
         # Ubuntu Trusty and other still ship with setuptools < 17.1
-        ':python_version == "2.7"': [
+        ':python_version == "2.7" or python_version == "3.3"': [
             "win_inet_pton >= 1.0.1"  # available on 3.4+
-        ],
-        ':python_version == "3.3"': [
-            "win_inet_pton >= 1.0.1"  # available on 3.4+
-        ],
+        ]
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,9 @@
 import os
 
 import pydivert
+from setuptools import setup, find_packages
 
 __author__ = 'fabio'
-
-from setuptools import setup, find_packages
 
 workdir = os.path.abspath(os.path.dirname(__file__))
 
@@ -58,6 +57,18 @@ setup(
         'Topic :: Utilities',
     ],
     extras_require={
-        "testing": ["mock>=1.0.1"]
+        "test": [
+            "mock>=1.0.1",
+            "pytest>=3.0.3",
+            "wheel>=0.29",
+        ],
+        # Do not use a range operator here: https://bitbucket.org/pypa/setuptools/issues/380
+        # Ubuntu Trusty and other still ship with setuptools < 17.1
+        ':python_version == "2.7"': [
+            "win_inet_pton >= 1.0.1"  # available on 3.4+
+        ],
+        ':python_version == "3.3"': [
+            "win_inet_pton >= 1.0.1"  # available on 3.4+
+        ],
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
             "pytest-cov>=2.2.1",
             "pytest-timeout>=1.0.0, <2",
             "pytest-faulthandler>=1.3.0, <2",
+            "codecov>=2.0.5",
             "wheel>=0.29",
         ],
         # Do not use a range operator here: https://bitbucket.org/pypa/setuptools/issues/380


### PR DESCRIPTION
This PR introduces the following changes:

- Add appveyor.yml for continuous integration (see https://ci.appveyor.com/project/mhils/pydivert)
- Add codecov for coverage analysis (https://codecov.io/gh/mhils/pydivert/branch/refactor)
- Remove legacy support for WinDivert 1.0
- Remove encoding option for the handles. To be honest I did not really understand the purpose of that dance, did I miss something or are these just leftovers?
- Convert testsuite to use py.test. This integrates nicely with codecov, offers a few useful features (timeout detection with stack trace dump - I had hanging tests for which this was really useful), and IMHO a slightly more readable syntax for assertions.
- Fix tests for the changes introduced in #11 
- Mark `test_pass_through_mtu_size` as skipped - it looks like this test was flaky all along?
- Remove custom `socket.inet_pton/inet_ntop` implementation with the `win_inet_pton` package on Python 2.7 and 3.3. Both functions are implemented in Windows CPython on 3.4+.
- Replace `is_registered` logic with a call to `sc query` and remove all registry handling. This seems to be easier in total?

So yes, it went a bit overboard - sorry for that 😇. Overall we're -220 lines though, so that's pretty good I think.
@ffalcinelli, do you spot anything that should be adressed before we merge this?