### PR TITLE
Added fix to prevent writing __doc__ attribute under 3.5. 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,8 @@ environment:
   matrix:
     - python: 27
     - python: 27-x64
+    - python: 34
+    - python: 34-x64
     - python: 35
     - python: 35-x64
 

--- a/pydivert/packet/ip.py
+++ b/pydivert/packet/ip.py
@@ -17,7 +17,7 @@ import socket
 import struct
 
 from pydivert.packet.header import Header
-from pydivert.util import PY2
+from pydivert.util import PY2, PY34
 
 
 class IPHeader(Header):
@@ -78,7 +78,7 @@ class IPv4Header(IPHeader):
     def packet_len(self, val):
         self.raw[2:4] = struct.pack("!H", val)
 
-    if PY2:
+    if PY2 or PY34:
         pass
     else:
         packet_len.__doc__ = IPHeader.packet_len.__doc__
@@ -97,7 +97,7 @@ class IPv6Header(IPHeader):
     def packet_len(self, val):
         self.raw[4:6] = struct.pack("!H", val - 40)
 
-    if PY2:
+    if PY2 or PY34:
         pass
     else:
         packet_len.__doc__ = IPHeader.packet_len.__doc__

--- a/pydivert/packet/tcp.py
+++ b/pydivert/packet/tcp.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from pydivert.packet.header import Header, PayloadMixin, PortMixin
-from pydivert.util import indexbyte as i, PY2
+from pydivert.util import indexbyte as i, PY2, PY34
 
 
 def flagproperty(name, bit):
@@ -32,8 +32,8 @@ def flagproperty(name, bit):
 
         self.raw[13] = i(flags)
 
-    if PY2:
-        pass  # .__doc__ is readonly on Python 2.
+    if PY2 or PY34:
+        pass  # .__doc__ is readonly on Python 2 and under 3.5.
     else:
         flag.__doc__ = """
             Indicates if the {} flag is set.

--- a/pydivert/packet/udp.py
+++ b/pydivert/packet/udp.py
@@ -16,7 +16,7 @@
 import struct
 
 from pydivert.packet.header import Header, PayloadMixin, PortMixin
-from pydivert.util import PY2
+from pydivert.util import PY2, PY34
 
 
 class UDPHeader(Header, PayloadMixin, PortMixin):
@@ -31,7 +31,7 @@ class UDPHeader(Header, PayloadMixin, PortMixin):
         PayloadMixin.payload.fset(self, val)
         self.payload_len = len(val)
 
-    if PY2:
+    if PY2 or PY34:
         pass
     else:
         payload.__doc__ = PayloadMixin.payload.__doc__

--- a/pydivert/util.py
+++ b/pydivert/util.py
@@ -40,7 +40,13 @@ if sys.version_info < (3, 0):
     # python 3's bytes.fromhex()
     fromhex = lambda x: x.decode("hex")
     PY2 = True
+    PY34 = False
 else:
     indexbyte = lambda x: x
     fromhex = lambda x: bytes.fromhex(x)
     PY2 = False
+    if sys.version_info < (3, 5):
+        # __doc__ attribute is only writable from 3.5.
+        PY34 = True
+    else:
+        PY34 = False


### PR DESCRIPTION
The ` __doc__` attribute is only writeable from 3.5. Python 3.4 fails with AttributeError when assigning the new `__doc__` values. To prevent that, I've added a PY34 variable (just like PY2 and PY3) that will be True if the version number is under 3.5 and extended the conditions where the `__doc__` attributes are assigned.

I've also added version 3.4 and 34-x64 to the AppVeyor config. 