### PR TITLE
Add Direction to public API

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,3 +47,7 @@ PyDivert API Reference
 .. autoclass:: pydivert.CalcChecksumsOption
     :members:
     :undoc-members:
+
+.. autoclass:: pydivert.Direction
+    :members:
+    :undoc-members:

--- a/pydivert/__init__.py
+++ b/pydivert/__init__.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import sys as _sys
 
-from .consts import Layer, Flag, Param, CalcChecksumsOption
+from .consts import Layer, Flag, Param, CalcChecksumsOption, Direction
 from .packet import Packet
 from .windivert import WinDivert
 
@@ -31,5 +31,5 @@ if _sys.version_info < (3, 4):
 __all__ = [
     "WinDivert",
     "Packet",
-    "Layer", "Flag", "Param", "CalcChecksumsOption",
+    "Layer", "Flag", "Param", "CalcChecksumsOption", "Direction",
 ]


### PR DESCRIPTION
While upgrading mitmproxy to PyDivert 2.0, I noticed that we missed to expose Direction! :smiley: