### PR TITLE
Error when setting traffic_class on IPv6Header 

### DIFF
--- a/pydivert/packet/ip.py
+++ b/pydivert/packet/ip.py
@@ -177,8 +177,7 @@ class IPv6Header(IPHeader):
 
     @traffic_class.setter
     def traffic_class(self, val):
-        struct.pack_into('!H', self.raw, 0, 0x6000 | (val << 4) | (self.flow_label & 0x000F0000))
-
+        struct.pack_into('!H', raw, 0, 0x6000 | (val << 4) | ((flow_label & 0x000F0000) >> 16))
     @property
     def flow_label(self):
         """

--- a/pydivert/packet/ip.py
+++ b/pydivert/packet/ip.py
@@ -177,7 +177,7 @@ class IPv6Header(IPHeader):
 
     @traffic_class.setter
     def traffic_class(self, val):
-        struct.pack_into('!H', raw, 0, 0x6000 | (val << 4) | ((flow_label & 0x000F0000) >> 16))
+        struct.pack_into('!H', self.raw, 0, 0x6000 | (val << 4) | ((self.flow_label & 0x000F0000) >> 16))
     @property
     def flow_label(self):
         """


### PR DESCRIPTION
We found an error when setting `self.traffic_class` on `IPv6Header` when `self.flow_label` is greater then 2 bytes.
I added a shift-right by 16 and it fixed.