### PR TITLE
🔒 [security] Use absolute path for service control to prevent path hijacking

### DIFF
--- a/pydivert/tests/test_coverage_bonus_2.py
+++ b/pydivert/tests/test_coverage_bonus_2.py
@@ -8,18 +8,23 @@ from pydivert.packet import Packet
 
 
 def test_windivert_unregister_fallback():
+    import os
+
     with patch("pydivert.service.stop_service", return_value=False):
         with patch("subprocess.run") as mock_run:
             pydivert.WinDivert.unregister()
             mock_run.assert_called_once()
             args = mock_run.call_args[0][0]
-            assert args == ["sc", "stop", "WinDivert"]
+            sc_path = os.path.join(os.environ.get("SystemRoot", "C:\\Windows"), "System32", "sc.exe")
+            assert args == [sc_path, "stop", "WinDivert"]
+
 
 def test_check_filter_os_error():
     with patch("pydivert.windivert_dll.WinDivertHelperCompileFilter", side_effect=OSError("Mocked OS Error")):
         res, pos, msg = pydivert.WinDivert.check_filter("true")
         assert res is False
         assert msg == ""
+
 
 @pytest.mark.asyncio
 async def test_async_closed_handle_error():
@@ -30,13 +35,14 @@ async def test_async_closed_handle_error():
     with pytest.raises(RuntimeError, match="WinDivert handle is not open"):
         await w.send_async(Packet(bytearray(20)))
 
+
 @pytest.mark.asyncio
 async def test_recv_async_error_path():
     with patch("pydivert.windivert.windivert_dll") as mock_dll:
         mock_dll.WinDivertOpen.return_value = 123
         mock_dll.CreateEventW.return_value = 456
         mock_dll.WinDivertRecvEx.return_value = False
-        mock_dll.GetLastError.return_value = 1234 # Not ERROR_IO_PENDING
+        mock_dll.GetLastError.return_value = 1234  # Not ERROR_IO_PENDING
         mock_dll.WinError.side_effect = lambda code: OSError(None, "Mocked WinError", None, code)
 
         async with pydivert.WinDivert() as w:
@@ -44,13 +50,14 @@ async def test_recv_async_error_path():
                 await w.recv_async()
             assert len(w._pending_ops) == 0
 
+
 @pytest.mark.asyncio
 async def test_send_async_error_path():
     with patch("pydivert.windivert.windivert_dll") as mock_dll:
         mock_dll.WinDivertOpen.return_value = 123
         mock_dll.CreateEventW.return_value = 456
         mock_dll.WinDivertSendEx.return_value = False
-        mock_dll.GetLastError.return_value = 1234 # Not ERROR_IO_PENDING
+        mock_dll.GetLastError.return_value = 1234  # Not ERROR_IO_PENDING
         mock_dll.WinError.side_effect = lambda code: OSError(None, "Mocked WinError", None, code)
 
         async with pydivert.WinDivert() as w:
@@ -60,6 +67,7 @@ async def test_send_async_error_path():
             with pytest.raises(OSError):
                 await w.send_async(p)
             assert len(w._pending_ops) == 0
+
 
 @pytest.mark.asyncio
 async def test_recv_async_exception_path():
@@ -73,6 +81,7 @@ async def test_recv_async_exception_path():
             with pytest.raises(RuntimeError, match="Unexpected"):
                 await w.recv_async()
             assert len(w._pending_ops) == 0
+
 
 @pytest.mark.asyncio
 async def test_send_async_exception_path():
@@ -90,6 +99,7 @@ async def test_send_async_exception_path():
                 await w.send_async(p)
             assert len(w._pending_ops) == 0
 
+
 def test_recv_ex_error_path():
     with patch("pydivert.windivert.windivert_dll") as mock_dll:
         mock_dll.WinDivertOpen.return_value = 123
@@ -99,6 +109,7 @@ def test_recv_ex_error_path():
         w._handle = 123
         with pytest.raises(OSError):
             w.recv_ex()
+
 
 def test_send_ex_error_path():
     with patch("pydivert.windivert.windivert_dll") as mock_dll:
@@ -112,36 +123,42 @@ def test_send_ex_error_path():
         with pytest.raises(OSError):
             w.send_ex(p)
 
+
 def test_packet_is_checksum_valid_udp():
     # IPv4 + UDP
     raw = bytearray(
-        b"\x45\x00\x00\x1c" # IPv4
+        b"\x45\x00\x00\x1c"  # IPv4
         b"\x00\x01\x00\x00"
-        b"\x40\x11\x00\x00" # UDP (17 = 0x11)
-        b"\x7f\x00\x00\x01" # 127.0.0.1
+        b"\x40\x11\x00\x00"  # UDP (17 = 0x11)
+        b"\x7f\x00\x00\x01"  # 127.0.0.1
         b"\x7f\x00\x00\x01"
-        b"\x12\x34\x12\x35" # Source port, Destination port
-        b"\x00\x08\x00\x00" # Length 8, Checksum 0
+        b"\x12\x34\x12\x35"  # Source port, Destination port
+        b"\x00\x08\x00\x00"  # Length 8, Checksum 0
     )
     p = Packet(raw)
     assert not p.is_checksum_valid
 
     # Mock WinDivertHelperCalcChecksums to return success
     with patch("pydivert.windivert_dll.WinDivertHelperCalcChecksums", return_value=1):
-        assert p.is_checksum_valid # other.udp.cksum = 0 is hit here in is_checksum_valid
+        assert p.is_checksum_valid  # other.udp.cksum = 0 is hit here in is_checksum_valid
+
 
 def test_ip_packet_len_direct_access():
     from pydivert.packet.ip import IPv4Header
+
     raw = bytearray(b"\x45\x00\x00\x14\x00\x00\x00\x00\x40\x06\x00\x00\x7f\x00\x00\x01\x7f\x00\x00\x01")
     p = Packet(raw)
     header = IPv4Header(p)
     assert header.packet_len == 20
 
+
 def test_windivert_dll_set_last_error_no_windll():
     from pydivert import windivert_dll
+
     with patch("pydivert.windivert_dll.windll", None):
         # Should return None instead of calling windll.kernel32.SetLastError
         assert windivert_dll.SetLastError(0) is None
+
 
 @pytest.mark.asyncio
 async def test_recv_async_cancellation():
@@ -151,7 +168,7 @@ async def test_recv_async_cancellation():
         mock_dll.ERROR_IO_PENDING = 997
         # Simulate pending IO
         mock_dll.WinDivertRecvEx.return_value = False
-        mock_dll.GetLastError.return_value = 997 # ERROR_IO_PENDING
+        mock_dll.GetLastError.return_value = 997  # ERROR_IO_PENDING
         mock_dll.WinError.side_effect = lambda code: OSError(None, "Mocked WinError", None, code)
 
         with patch("asyncio.get_running_loop") as mock_loop:
@@ -170,6 +187,7 @@ async def test_recv_async_cancellation():
                     await task
                 assert len(w._pending_ops) == 1
 
+
 @pytest.mark.asyncio
 async def test_send_async_cancellation():
     with patch("pydivert.windivert.windivert_dll") as mock_dll:
@@ -178,7 +196,7 @@ async def test_send_async_cancellation():
         mock_dll.ERROR_IO_PENDING = 997
         # Simulate pending IO
         mock_dll.WinDivertSendEx.return_value = False
-        mock_dll.GetLastError.return_value = 997 # ERROR_IO_PENDING
+        mock_dll.GetLastError.return_value = 997  # ERROR_IO_PENDING
         mock_dll.WinError.side_effect = lambda code: OSError(None, "Mocked WinError", None, code)
 
         with patch("asyncio.get_running_loop") as mock_loop:
@@ -200,6 +218,7 @@ async def test_send_async_cancellation():
                     await task
                 assert len(w._pending_ops) == 1
 
+
 def test_send_ex_sync_success():
     with patch("pydivert.windivert.windivert_dll") as mock_dll:
         mock_dll.WinDivertOpen.return_value = 123
@@ -208,13 +227,16 @@ def test_send_ex_sync_success():
         w = pydivert.WinDivert()
         w._handle = 123
         p = Packet(bytearray(b"\x45" + b"\x00" * 19))
-        assert w.send_ex(p) == 0 # send_len.value
+        assert w.send_ex(p) == 0  # send_len.value
+
 
 def test_ip_header_base_packet_len():
     from pydivert.packet.ip import IPHeader
+
     p = Packet(bytearray(b"\x00" * 20))
     header = IPHeader(p)
     assert header.packet_len == 20
+
 
 def test_windivert_is_registered_coverage():
     with patch("pydivert.service.is_registered", return_value=True):

--- a/pydivert/windivert.py
+++ b/pydivert/windivert.py
@@ -25,6 +25,7 @@
 import asyncio
 import ctypes
 import logging
+import os
 import subprocess
 from ctypes import byref, c_char, c_char_p, c_uint, c_uint64
 
@@ -136,7 +137,8 @@ class WinDivert:
         """
         if not service.stop_service():
             # Fallback to sc.exe if direct Win32 API fails
-            subprocess.run(["sc", "stop", "WinDivert"], capture_output=True)
+            sc_path = os.path.join(os.environ.get("SystemRoot", "C:\\Windows"), "System32", "sc.exe")
+            subprocess.run([sc_path, "stop", "WinDivert"], capture_output=True)
 
     @staticmethod
     def check_filter(filter: str, layer: Layer = Layer.NETWORK) -> tuple[bool, int, str]:


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The `WinDivert.unregister()` method was using a relative path for the `sc` command in a `subprocess.run` call, which could lead to path hijacking.

⚠️ **Risk:** The potential impact if left unfixed
A malicious user or process could place a Trojan horse `sc.exe` in a directory that is searched before the official Windows `System32` directory. If `pydivert` runs with elevated privileges (which is common for network manipulation tools), this could lead to arbitrary code execution with those privileges.

🛡️ **Solution:** How the fix addresses the vulnerability
The fix uses an absolute path to the legitimate `sc.exe` utility, typically located at `%SystemRoot%\System32\sc.exe`. This ensures that the intended system utility is always executed, regardless of the contents of the `PATH` environment variable.


---
*PR created automatically by Jules for task [18076455635375224516](https://jules.google.com/task/18076455635375224516) started by @ffalcinelli*