### PR TITLE
🔒 Fix arbitrary execution vulnerability during doc build

### DIFF
--- a/docs/build.py
+++ b/docs/build.py
@@ -11,9 +11,6 @@ here = os.path.dirname(os.path.abspath(__file__))
 root = os.path.dirname(here)
 os.chdir(root)
 
-# Set environment variable to allow pdoc to execute things if needed
-os.environ["PDOC_ALLOW_EXEC"] = "1"
-
 def get_tags():
     """Retrieve and sort all tags starting with 'v'."""
     try:


### PR DESCRIPTION
🎯 **What:** Removed `os.environ["PDOC_ALLOW_EXEC"] = "1"` from `docs/build.py`.
⚠️ **Risk:** By explicitly setting this variable, `pdoc` is granted permission to execute subprocesses. This meant any malicious code or unexpected side effects present in the `pydivert` imports could be arbitrarily executed when building the docs, representing a security vulnerability.
🛡️ **Solution:** Removed the explicit environment variable setting, restoring `pdoc`'s default secure behavior. Testing confirms the documentation still builds successfully without it.

---
*PR created automatically by Jules for task [15042700634697519430](https://jules.google.com/task/15042700634697519430) started by @ffalcinelli*