### PR TITLE
🧪 Add handle validation checks and tests

### DIFF
--- a/pydivert/tests/test_handle_validation.py
+++ b/pydivert/tests/test_handle_validation.py
@@ -1,8 +1,11 @@
-import pytest
-from pydivert.windivert import WinDivert
-from pydivert.consts import Param
 from unittest.mock import MagicMock
+
+import pytest
+
 import pydivert
+from pydivert.consts import Param
+from pydivert.windivert import WinDivert
+
 
 @pytest.mark.parametrize("method_name, args", [
     ("recv", []),
@@ -19,12 +22,14 @@ def test_sync_methods_raise_without_open(method_name, args):
         method(*args)
     assert "WinDivert handle is not open" in str(excinfo.value)
 
+
 @pytest.mark.asyncio
 async def test_recv_async_raises_without_open():
     w = WinDivert("false")
     with pytest.raises(RuntimeError) as excinfo:
         await w.recv_async()
     assert "WinDivert handle is not open" in str(excinfo.value)
+
 
 @pytest.mark.asyncio
 async def test_send_async_raises_without_open():

--- a/pydivert/tests/test_handle_validation.py
+++ b/pydivert/tests/test_handle_validation.py
@@ -1,0 +1,35 @@
+import pytest
+from pydivert.windivert import WinDivert
+from pydivert.consts import Param
+from unittest.mock import MagicMock
+import pydivert
+
+@pytest.mark.parametrize("method_name, args", [
+    ("recv", []),
+    ("recv_ex", []),
+    ("send", [MagicMock(spec=pydivert.Packet)]),
+    ("send_ex", [MagicMock(spec=pydivert.Packet)]),
+    ("get_param", [Param.QUEUE_LEN]),
+    ("set_param", [Param.QUEUE_LEN, 1024]),
+])
+def test_sync_methods_raise_without_open(method_name, args):
+    w = WinDivert("false")
+    method = getattr(w, method_name)
+    with pytest.raises(RuntimeError) as excinfo:
+        method(*args)
+    assert "WinDivert handle is not open" in str(excinfo.value)
+
+@pytest.mark.asyncio
+async def test_recv_async_raises_without_open():
+    w = WinDivert("false")
+    with pytest.raises(RuntimeError) as excinfo:
+        await w.recv_async()
+    assert "WinDivert handle is not open" in str(excinfo.value)
+
+@pytest.mark.asyncio
+async def test_send_async_raises_without_open():
+    w = WinDivert("false")
+    packet = MagicMock(spec=pydivert.Packet)
+    with pytest.raises(RuntimeError) as excinfo:
+        await w.send_async(packet)
+    assert "WinDivert handle is not open" in str(excinfo.value)

--- a/pydivert/windivert.py
+++ b/pydivert/windivert.py
@@ -406,6 +406,9 @@ class WinDivert:
 
         :return: The return value is the number of bytes actually sent.
         """
+        if self._handle is None:
+            raise RuntimeError("WinDivert handle is not open")
+
         if recalculate_checksum:
             packet.recalculate_checksums()
 
@@ -502,6 +505,9 @@ class WinDivert:
         :param overlapped: An optional `Overlapped` structure for overlapped IO.
         :return: The number of bytes sent if synchronous, or `None` if `ERROR_IO_PENDING` occurred.
         """
+        if self._handle is None:
+            raise RuntimeError("WinDivert handle is not open")
+
         if recalculate_checksum:
             packet.recalculate_checksums()
 
@@ -544,6 +550,9 @@ class WinDivert:
 
         :return: The parameter value.
         """
+        if self._handle is None:
+            raise RuntimeError("WinDivert handle is not open")
+
         value = c_uint64(0)
         windivert_dll.WinDivertGetParam(self._handle, name, byref(value))  # type: ignore[attr-defined]
         return value.value
@@ -562,4 +571,7 @@ class WinDivert:
 
         For more info on the C call visit: https://reqrypt.org/windivert-doc.html#divert_set_param
         """
+        if self._handle is None:
+            raise RuntimeError("WinDivert handle is not open")
+
         return windivert_dll.WinDivertSetParam(self._handle, name, value)  # type: ignore[attr-defined]


### PR DESCRIPTION
🎯 **What:** This change ensures that all `WinDivert` methods that require an open handle (including `send`, `send_ex`, `get_param`, and `set_param`) explicitly check for it and raise a `RuntimeError` if called before `open()`. Previously, some methods like `recv_ex` had this check, but others were missing it.

📊 **Coverage:** A new test file `pydivert/tests/test_handle_validation.py` has been added, covering:
- Synchronous methods: `recv`, `recv_ex`, `send`, `send_ex`, `get_param`, `set_param`.
- Asynchronous methods: `recv_async`, `send_async`.

✨ **Result:** Improved robustness and consistency across the `WinDivert` class, preventing potential issues when methods are called out of order. Coverage for state validation has been increased.

---
*PR created automatically by Jules for task [17110378559559740216](https://jules.google.com/task/17110378559559740216) started by @ffalcinelli*