### PR TITLE
🧪 [testing improvement] Add edge case test for Packet.ipv6()

### DIFF
--- a/pydivert/tests/test_packet.py
+++ b/pydivert/tests/test_packet.py
@@ -658,3 +658,10 @@ def test_ip_addr_invalid_length():
     assert p6_partial.address_family == socket.AF_INET6
     assert p6_partial.src_addr == "::"
     assert p6_partial.dst_addr is None
+
+
+def test_ipv6_property_non_ipv6():
+    """Test that the ipv6 property returns None when address_family is not AF_INET6."""
+    packet = p(ipv4_hdr)
+    assert packet.address_family == socket.AF_INET
+    assert packet.ipv6 is None


### PR DESCRIPTION
🎯 **What:** This PR addresses a testing gap where the `Packet.ipv6` property's behavior was not verified when called on non-IPv6 packets (e.g. IPv4).
📊 **Coverage:** A test case `test_ipv6_property_non_ipv6` is added, specifically building an IPv4 packet, ensuring its address family is `AF_INET`, and verifying `.ipv6` returns `None`.
✨ **Result:** Test coverage improved by properly covering this previously unchecked edge case. The tests successfully verify that invalid logic paths correctly return `None`.

---
*PR created automatically by Jules for task [441941103258211352](https://jules.google.com/task/441941103258211352) started by @ffalcinelli*