### PR TITLE
docs: add WinDivert filter language guide and improve security docume…

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![python_versions](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue.svg)](https://pypi.python.org/pypi/pydivert)
 [![windows](https://img.shields.io/badge/os-windows%2011-blue.svg)](https://pypi.python.org/pypi/pydivert)
 [![license](https://img.shields.io/pypi/l/pydivert.svg)](https://github.com/ffalcinelli/pydivert/blob/main/LICENSE)
-[![Snyk](https://snyk.io/test/github/ffalcinelli/pydivert/badge.svg?targetFile=pyproject.toml)](https://snyk.io/test/github/ffalcinelli/pydivert?targetFile=pyproject.toml)
 
 **PyDivert** is a powerful Python binding for [WinDivert](https://reqrypt.org/windivert.html), a Windows driver that allows user-mode applications to capture, modify, and drop network packets sent to or from the Windows network stack.
 
@@ -176,6 +175,12 @@ Detailed protocol headers are available through `packet.ipv4`, `packet.ipv6`, `p
 - `Flag.FRAGMENTS`: Capture all IP fragments.
 - `Flag.RECV_ONLY` / `Flag.SEND_ONLY`: Restricted handles.
 
+## Filter Language
+
+PyDivert uses the WinDivert filter language to select which packets to capture. For a detailed reference on the syntax and available fields, see the [Filter Language Guide](#windivert-filter-language).
+
+For the original technical reference, please visit the [official WinDivert documentation](https://reqrypt.org/windivert-doc.html#filter_language).
+
 ## WinDivert Version Compatibility
 
 | PyDivert | WinDivert |
@@ -203,4 +208,8 @@ The full API documentation is available at [https://ffalcinelli.github.io/pydive
 
 ## License
 
-PyDivert is dual-licensed under **LGPL-3.0-or-later** and **GPL-2.0-or-later**.
+PyDivert is dual-licensed under [LGPL-3.0-or-later](https://github.com/ffalcinelli/pydivert/blob/main/LICENSE-LGPL-3.0-or-later) and [GPL-2.0-or-later](https://github.com/ffalcinelli/pydivert/blob/main/LICENSE-GPL-2.0-or-later).
+
+## Security
+
+PyDivert is committed to security and uses [Snyk](https://snyk.io/) for continuous vulnerability scanning. For more details on our security practices and how to report vulnerabilities, please refer to the [Security Policy](#security-policy).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,6 +9,10 @@ Currently, the following versions of PyDivert are supported with security update
 | 3.0.x   | :white_check_mark: Supported   |
 | < 3.0   | :x: Unsupported       |
 
+## Vulnerability Scanning
+
+We use [Snyk](https://snyk.io/) to continuously monitor the PyDivert codebase and its dependencies for known vulnerabilities. This scanning is integrated into our CI/CD pipeline to ensure that security is maintained throughout the development lifecycle.
+
 ## Reporting a Vulnerability
 
 If you discover a potential security vulnerability in PyDivert, please do **not** open a public issue. Instead, report it privately to the maintainers:

--- a/docs/FILTER_LANGUAGE.md
+++ b/docs/FILTER_LANGUAGE.md
@@ -1,0 +1,114 @@
+# WinDivert Filter Language
+
+This page provides a detailed reference for the WinDivert filter language syntax, which is used by PyDivert to capture specific network packets.
+
+> [!NOTE]
+> This documentation is based on the original [WinDivert Filter Language Documentation](https://reqrypt.org/windivert-doc.html#filter_language). Credits go to the original WinDivert authors for their excellent work and comprehensive documentation.
+
+## Overview
+
+A WinDivert filter is a string representing a boolean expression that is evaluated for each packet (or event) seen by the driver. If the expression evaluates to `true`, the packet is diverted to the PyDivert handle; otherwise, it is ignored.
+
+## Syntax
+
+### Boolean Operators
+
+The filter language supports standard boolean operators with the following precedence (from highest to lowest):
+
+1.  `!` (NOT)
+2.  `&&` (AND)
+3.  `||` (OR)
+
+### Relational Operators
+
+Relational operators can be used to compare fields with constants or other fields:
+
+- `==` (equal)
+- `!=` (not equal)
+- `<` (less than)
+- `>` (greater than)
+- `<=` (less than or equal)
+- `>=` (greater than or equal)
+
+### Layers
+
+Filters can target different layers. Each layer has specific fields available:
+
+- `Layer.NETWORK`: Captures IP packets.
+- `Layer.FLOW`: Captures connection-oriented events (TCP/UDP).
+- `Layer.SOCKET`: Captures socket-level events (bind, connect, etc.).
+- `Layer.REFLECT`: Captures reflected events.
+
+## Protocols and Fields
+
+### IP Layer (IPv4 and IPv6)
+
+Common fields for both IPv4 and IPv6:
+
+- `ip.SrcAddr`: Source IP address.
+- `ip.DstAddr`: Destination IP address.
+- `ip.Protocol`: IP protocol number (e.g., 6 for TCP, 17 for UDP).
+- `ip.TTL` / `ipv6.HopLimit`: Time-to-live or Hop limit.
+- `ip.Length` / `ipv6.Length`: Total length of the packet.
+
+Example: `ip.SrcAddr == 192.168.1.1`
+
+### TCP
+
+Fields available when the packet is TCP:
+
+- `tcp.SrcPort`: Source port.
+- `tcp.DstPort`: Destination port.
+- `tcp.Flags`: TCP flags.
+- `tcp.Syn`, `tcp.Ack`, `tcp.Fin`, `tcp.Rst`, `tcp.Psh`, `tcp.Urg`: Individual TCP flag booleans.
+- `tcp.PayloadLength`: Length of the TCP payload in bytes.
+
+Example: `tcp.DstPort == 80 && tcp.Syn`
+
+### UDP
+
+Fields available when the packet is UDP:
+
+- `udp.SrcPort`: Source port.
+- `udp.DstPort`: Destination port.
+- `udp.Length`: UDP header + payload length.
+
+Example: `udp.DstPort == 53` (DNS traffic)
+
+### ICMP and ICMPv6
+
+- `icmp.Type`: ICMP type.
+- `icmp.Code`: ICMP code.
+- `icmpv6.Type`: ICMPv6 type.
+- `icmpv6.Code`: ICMPv6 code.
+
+## Metadata and Flags
+
+WinDivert provides several pseudo-fields representing metadata about the packet:
+
+- `inbound`: Packet is inbound (coming from the network).
+- `outbound`: Packet is outbound (sent by a local application).
+- `loopback`: Packet is a loopback packet.
+- `impostor`: Packet was injected by another application (e.g., another WinDivert handle).
+- `ifIdx`: The interface index.
+- `subIfIdx`: The sub-interface index.
+
+Example: `outbound && tcp.DstPort == 443` (Outbound HTTPS traffic)
+
+## Helper Functions
+
+- `htons(port)`: Converts a port number to network byte order. (Usually not needed as WinDivert handles this automatically for constants).
+- `ntohs(port)`: Converts a port number from network byte order.
+
+## Advanced Examples
+
+- **Capture all HTTP and HTTPS traffic**:
+  `(tcp.DstPort == 80 || tcp.DstPort == 443) || (tcp.SrcPort == 80 || tcp.SrcPort == 443)`
+- **Capture all traffic except from a specific IP**:
+  `!(ip.SrcAddr == 1.2.3.4)`
+- **Capture TCP SYN packets to port 22 (SSH)**:
+  `tcp.DstPort == 22 && tcp.Syn && !tcp.Ack`
+- **Capture loopback traffic**:
+  `loopback`
+
+For more information and a complete list of all available fields, please refer to the [official WinDivert documentation](https://reqrypt.org/windivert-doc.html#filter_language).

--- a/pydivert/__init__.py
+++ b/pydivert/__init__.py
@@ -24,6 +24,7 @@
 
 """
 .. include:: ../README.md
+.. include:: ../docs/FILTER_LANGUAGE.md
 .. include:: ../SECURITY.md
 """
 

--- a/pydivert/windivert.py
+++ b/pydivert/windivert.py
@@ -63,7 +63,8 @@ class WinDivert:
         """
         Creates a WinDivert handle.
 
-        :param filter: The packet filter string (e.g. "tcp.DstPort == 80").
+        :param filter: The packet filter string (e.g. "tcp.DstPort == 80"). 
+            See the [WinDivert Filter Language](#windivert-filter-language) guide for more details.
         :param layer: The WinDivert layer (e.g. Layer.NETWORK, Layer.FLOW).
         :param priority: The priority of the handle (higher priority handles see packets first).
         :param flags: WinDivert flags (e.g. Flag.SNIFF, Flag.DROP).

--- a/pydivert/windivert.py
+++ b/pydivert/windivert.py
@@ -63,7 +63,7 @@ class WinDivert:
         """
         Creates a WinDivert handle.
 
-        :param filter: The packet filter string (e.g. "tcp.DstPort == 80"). 
+        :param filter: The packet filter string (e.g. "tcp.DstPort == 80").
             See the [WinDivert Filter Language](#windivert-filter-language) guide for more details.
         :param layer: The WinDivert layer (e.g. Layer.NETWORK, Layer.FLOW).
         :param priority: The priority of the handle (higher priority handles see packets first).


### PR DESCRIPTION
- Add docs/FILTER_LANGUAGE.md with a detailed reference of the filter language.
- Include the guide in pdoc documentation via pydivert/__init__.py.
- Update README.md with a new Filter Language section and improved license links.
- Replace the broken Snyk badge in README.md with a dedicated Security section.
- Update SECURITY.md with information about Snyk vulnerability scanning.
- Add anchor links to WinDivert filter language guide in class docstrings.