### PR TITLE
security: fix CWE-78 command injection in WinDivert.unregister

### DIFF
--- a/pydivert/tests/test_coverage_bonus_2.py
+++ b/pydivert/tests/test_coverage_bonus_2.py
@@ -8,15 +8,16 @@ from pydivert.packet import Packet
 
 
 def test_windivert_unregister_fallback():
-    import os
-
     with patch("pydivert.service.stop_service", return_value=False):
         with patch("subprocess.run") as mock_run:
             pydivert.WinDivert.unregister()
             mock_run.assert_called_once()
             args = mock_run.call_args[0][0]
-            sc_path = os.path.join(os.environ.get("SystemRoot", "C:\\Windows"), "System32", "sc.exe")
-            assert args == [sc_path, "stop", "WinDivert"]
+            # On Linux/Mock, the fallback C:\Windows\System32 should be used
+            import os
+            expected_sc_path = os.path.join("C:\\Windows\\System32", "sc.exe")
+            assert os.path.normcase(args[0]) == os.path.normcase(expected_sc_path)
+            assert args[1:] == ["stop", "WinDivert"]
 
 
 def test_check_filter_os_error():

--- a/pydivert/windivert.py
+++ b/pydivert/windivert.py
@@ -138,7 +138,19 @@ class WinDivert:
         """
         if not service.stop_service():
             # Fallback to sc.exe if direct Win32 API fails
-            sc_path = os.path.join(os.environ.get("SystemRoot", "C:\\Windows"), "System32", "sc.exe")
+            try:
+                import ctypes.wintypes
+
+                buf = ctypes.create_unicode_buffer(ctypes.wintypes.MAX_PATH)
+                length = ctypes.windll.kernel32.GetSystemDirectoryW(buf, ctypes.wintypes.MAX_PATH)  # type: ignore[attr-defined]
+                if 0 < length <= ctypes.wintypes.MAX_PATH:
+                    system32 = buf.value
+                else:
+                    system32 = "C:\\Windows\\System32"
+            except (AttributeError, OSError, ImportError):
+                system32 = "C:\\Windows\\System32"
+
+            sc_path = os.path.join(system32, "sc.exe")
             subprocess.run([sc_path, "stop", "WinDivert"], capture_output=True)
 
     @staticmethod


### PR DESCRIPTION
- Securely resolve the path to the Windows System32 directory using GetSystemDirectoryW instead of the untrusted SystemRoot environment variable.
- Use a safe fallback to C:\Windows\System32.
- Update test_windivert_unregister_fallback to verify the fix and use os.path.normcase for cross-platform compatibility.
- Fix mypy error by ignoring attr-defined on ctypes.windll.