### PR TITLE
🔒 [security] fix unchecked subprocess call in WinDivert.unregister

### DIFF
--- a/pydivert/tests/test_coverage_bonus_2.py
+++ b/pydivert/tests/test_coverage_bonus_2.py
@@ -325,3 +325,17 @@ def test_ip_header_base_packet_len():
 def test_windivert_is_registered_coverage():
     with patch("pydivert.service.is_registered", return_value=True):
         assert pydivert.WinDivert.is_registered() is True
+
+def test_windivert_unregister_raises_on_failure():
+    import subprocess
+    with patch("pydivert.service.stop_service", return_value=False):
+        with patch("subprocess.run") as mock_run:
+            # Configure mock to behave like check=True failed
+            mock_run.side_effect = subprocess.CalledProcessError(1, ["sc.exe", "stop", "WinDivert"])
+
+            with pytest.raises(subprocess.CalledProcessError):
+                pydivert.WinDivert.unregister()
+
+            mock_run.assert_called_once()
+            _, kwargs = mock_run.call_args
+            assert kwargs.get("check") is True

--- a/pydivert/windivert.py
+++ b/pydivert/windivert.py
@@ -151,7 +151,7 @@ class WinDivert:
                 system32 = "C:\\Windows\\System32"
 
             sc_path = os.path.join(system32, "sc.exe")
-            subprocess.run([sc_path, "stop", "WinDivert"], capture_output=True)
+            subprocess.run([sc_path, "stop", "WinDivert"], capture_output=True, check=True)
 
     @staticmethod
     def check_filter(filter: str, layer: Layer = Layer.NETWORK) -> tuple[bool, int, str]:


### PR DESCRIPTION
🎯 **What:** Fixed an unchecked subprocess call in `WinDivert.unregister()`.
⚠️ **Risk:** If the `sc stop` command fails (e.g., due to permissions or system state), the failure would be silently ignored, potentially leaving the WinDivert service running when it should have been stopped.
🛡️ **Solution:** Added `check=True` to the `subprocess.run` call and included a new test case in `pydivert/tests/test_coverage_bonus_2.py` to verify that `CalledProcessError` is correctly raised on failure.

---
*PR created automatically by Jules for task [11523972392698246693](https://jules.google.com/task/11523972392698246693) started by @ffalcinelli*