### PR TITLE
Fix potential command injection in docs/build.py (fixes #123)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 3.1.3
+    - Security: Fixed a potential command injection vulnerability in the documentation build script (`docs/build.py`).
+    - Security: Implemented strict regex validation for git tags to prevent malicious tag names from affecting the build process.
+
 Version 3.1.2
     - Documentation: Added Snyk security badge to README.
     - CI/CD: Updated GitHub Actions workflows and refined security mandates.

--- a/docs/build.py
+++ b/docs/build.py
@@ -1,4 +1,5 @@
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -12,10 +13,12 @@ os.chdir(root)
 
 
 def get_tags():
-    """Retrieve and sort all tags starting with 'v'."""
+    """Retrieve and sort all tags starting with 'v' that follow a strict version pattern."""
     try:
         output = subprocess.check_output(["git", "tag", "-l", "v*"]).decode("utf-8")
-        tags = [t.strip() for t in output.split("\n") if t.strip()]
+        # Strict validation: only accept tags that match ^v\d+(\.\d+)*$
+        tag_pattern = re.compile(r"^v\d+(\.\d+)*$")
+        tags = [t.strip() for t in output.split("\n") if t.strip() and tag_pattern.match(t.strip())]
 
         def sort_key(tag):
             # Parse version into integer tuple for proper sorting (e.g. v3.1.0 -> (3, 1, 0))
@@ -167,7 +170,10 @@ def main():
                     shutil.rmtree(out_dir)
             finally:
                 if os.path.exists(wt_dir):
-                    subprocess.run(["git", "worktree", "remove", "-f", wt_dir], check=False, capture_output=True)
+                    # Use shutil.rmtree for safe directory removal
+                    shutil.rmtree(wt_dir, ignore_errors=True)
+                    # Prune the git worktree list without using dynamic paths in the command
+                    subprocess.run(["git", "worktree", "prune"], check=False, capture_output=True)
 
     # Build the latest (main) documentation
     print("Building latest documentation (current branch)...")

--- a/pydivert/__init__.py
+++ b/pydivert/__init__.py
@@ -33,7 +33,7 @@ from .packet import Packet
 from .windivert import WinDivert
 
 __author__ = "fabio"
-__version__ = "3.1.2"
+__version__ = "3.1.3"
 
 __all__ = [
     "WinDivert",


### PR DESCRIPTION
- Implemented strict regex validation for git tags.
- Replaced path-based git worktree removal with shutil.rmtree and git worktree prune.
- Bumped version to 3.1.3.