### PR TITLE
🧪 test: test coverage improvement for util.fromhex

### DIFF
--- a/pydivert/tests/test_coverage_complete.py
+++ b/pydivert/tests/test_coverage_complete.py
@@ -19,6 +19,8 @@ def test_util_fromhex():
     assert pydivert.util.fromhex("aabb") == b"\xaa\xbb"
     with pytest.raises(ValueError):
         pydivert.util.fromhex("a")
+    with pytest.raises(ValueError):
+        pydivert.util.fromhex("xx")
 
 
 def test_util_flag_property():


### PR DESCRIPTION
🎯 **What:** Adds a missing test coverage gap for the `fromhex` utility function.
📊 **Coverage:** The function is now tested to ensure it correctly raises a `ValueError` when provided a string containing invalid hexadecimal characters (e.g., "xx"). This complements the existing tests that check valid characters and incorrect string lengths.
✨ **Result:** Test coverage for the utility is improved and more robust.

---
*PR created automatically by Jules for task [1721609114964459315](https://jules.google.com/task/1721609114964459315) started by @ffalcinelli*