### PR TITLE
🧹 Fix unnecessary pass statements in BPF structures

### DIFF
--- a/pydivert/bpf/structs.py
+++ b/pydivert/bpf/structs.py
@@ -3,11 +3,11 @@ import ctypes
 
 
 class BpfObject(ctypes.Structure):
-    pass
+    """Opaque structure for BPF objects."""
 
 
 class BpfMap(ctypes.Structure):
-    pass
+    """Opaque structure for BPF maps."""
 
 
 class BpfTcHook(ctypes.Structure):


### PR DESCRIPTION
🎯 **What:** Replaced `pass` statements in `BpfObject` and `BpfMap` (within `pydivert/bpf/structs.py`) with descriptive docstrings.
💡 **Why:** This resolves Ruff's `PIE790` (unnecessary `pass` statement) while providing better documentation for these opaque `ctypes.Structure` classes.
✅ **Verification:** Verified with `uv run pytest` and `uv run --extra lint ruff check pydivert/bpf/structs.py`. No errors were found.
✨ **Result:** Cleaner code that is fully compliant with the project's linting rules without modifying functionality.

---
*PR created automatically by Jules for task [8419541629242204278](https://jules.google.com/task/8419541629242204278) started by @ffalcinelli*