### PR TITLE
🧪 [test] Improve coverage for TCP data offset limits

### DIFF
--- a/pydivert/packet/tcp.py
+++ b/pydivert/packet/tcp.py
@@ -90,7 +90,7 @@ class TCPHeader(Header, PortMixin, PayloadMixin):
     @data_offset.setter
     def data_offset(self, val: int):
         if not (5 <= val <= 15):
-            raise ValueError("TCP data offset must be between 5 and 15")  # pragma: no cover
+            raise ValueError("TCP data offset must be between 5 and 15")
         self._view.off_res_flags = (val << 12) | (self._view.off_res_flags & 0x0FFF)
         self._packet._invalidate_checksums()
 

--- a/pydivert/tests/test_packet.py
+++ b/pydivert/tests/test_packet.py
@@ -1,5 +1,6 @@
 import socket
 
+import pytest
 from hypothesis import example, given
 from hypothesis import strategies as st
 
@@ -156,6 +157,12 @@ def test_tcp_fields():
     assert not tcp.ack
     tcp.window = 1024
     assert tcp.window == 1024
+
+    with pytest.raises(ValueError, match="TCP data offset must be between 5 and 15"):
+        tcp.data_offset = 4
+
+    with pytest.raises(ValueError, match="TCP data offset must be between 5 and 15"):
+        tcp.data_offset = 16
 
 
 # --- Metadata ---


### PR DESCRIPTION
🎯 **What:** Added tests to verify the exception raised when invalid TCP data offset limits are given (offset < 5 or > 15).
📊 **Coverage:** Covered assigning 4 and 16 to `tcp.data_offset` verifying both lower and upper boundary error bounds. `# pragma: no cover` has also been removed.
✨ **Result:** Test coverage for `pydivert/packet/tcp.py`'s exception cases is improved.

---
*PR created automatically by Jules for task [14811800835036294011](https://jules.google.com/task/14811800835036294011) started by @ffalcinelli*