### PR TITLE
🧪 Add missing tests for packet direction and layer properties

### DIFF
--- a/pydivert/packet/__init__.py
+++ b/pydivert/packet/__init__.py
@@ -294,7 +294,7 @@ class Packet:
 
     @impostor.setter
     def impostor(self, val: bool) -> None:
-        self.is_impostor = val  # pragma: no cover
+        self.is_impostor = val
 
     @property
     def is_sniffed(self) -> bool:
@@ -312,7 +312,7 @@ class Packet:
 
     @sniffed.setter
     def sniffed(self, val: bool) -> None:
-        self.is_sniffed = val  # pragma: no cover
+        self.is_sniffed = val
 
     @property
     def is_inbound(self) -> bool:
@@ -362,8 +362,8 @@ class Packet:
 
     @event.setter
     def event(self, val: Any) -> None:
-        self._event = val  # pragma: no cover
-        self._wd_addr.Event = val  # pragma: no cover
+        self._event = val
+        self._wd_addr.Event = val
 
     @property
     def flow(self) -> Any | None:
@@ -372,9 +372,9 @@ class Packet:
 
     @flow.setter
     def flow(self, val: Any) -> None:
-        self._flow = val  # pragma: no cover
-        if val is not None and self._layer == Layer.FLOW:  # pragma: no cover
-            self._wd_addr.u.Flow = val  # pragma: no cover
+        self._flow = val
+        if val is not None and self._layer == Layer.FLOW:
+            self._wd_addr.u.Flow = val
 
     @property
     def socket(self) -> Any | None:
@@ -383,9 +383,9 @@ class Packet:
 
     @socket.setter
     def socket(self, val: Any) -> None:
-        self._socket = val  # pragma: no cover
-        if val is not None and self._layer == Layer.SOCKET:  # pragma: no cover
-            self._wd_addr.u.Socket = val  # pragma: no cover
+        self._socket = val
+        if val is not None and self._layer == Layer.SOCKET:
+            self._wd_addr.u.Socket = val
 
     @property
     def reflect(self) -> Any | None:
@@ -394,9 +394,9 @@ class Packet:
 
     @reflect.setter
     def reflect(self, val: Any) -> None:
-        self._reflect = val  # pragma: no cover
-        if val is not None and self._layer == Layer.REFLECT:  # pragma: no cover
-            self._wd_addr.u.Reflect = val  # pragma: no cover
+        self._reflect = val
+        if val is not None and self._layer == Layer.REFLECT:
+            self._wd_addr.u.Reflect = val
 
     @property
     def src_addr(self) -> str | None:
@@ -541,7 +541,7 @@ class Packet:
 
     @icmp_checksum.setter
     def icmp_checksum(self, val: bool) -> None:
-        self._icmp_checksum = val  # pragma: no cover
+        self._icmp_checksum = val
 
     def _invalidate_checksums(self):
         """Invalidate all checksum flags."""
@@ -622,11 +622,11 @@ class Packet:
         if self._layer in (Layer.NETWORK, Layer.NETWORK_FORWARD):
             address.u.Network.IfIdx, address.u.Network.SubIfIdx = self._interface
         elif self._layer == Layer.FLOW and self._flow:
-            address.u.Flow = self._flow  # pragma: no cover
+            address.u.Flow = self._flow
         elif self._layer == Layer.SOCKET and self._socket:
-            address.u.Socket = self._socket  # pragma: no cover
+            address.u.Socket = self._socket
         elif self._layer == Layer.REFLECT and self._reflect:
-            address.u.Reflect = self._reflect  # pragma: no cover
+            address.u.Reflect = self._reflect
 
         address.IPChecksum = 1 if self._ip_checksum else 0
         address.TCPChecksum = 1 if self._tcp_checksum else 0

--- a/pydivert/packet/__init__.py
+++ b/pydivert/packet/__init__.py
@@ -321,7 +321,7 @@ class Packet:
 
     @is_inbound.setter
     def is_inbound(self, val: bool) -> None:
-        self.direction = Direction.INBOUND if val else Direction.OUTBOUND  # pragma: no cover
+        self.direction = Direction.INBOUND if val else Direction.OUTBOUND
 
     @property
     def is_outbound(self) -> bool:
@@ -330,7 +330,7 @@ class Packet:
 
     @is_outbound.setter
     def is_outbound(self, val: bool) -> None:
-        self.direction = Direction.OUTBOUND if val else Direction.INBOUND  # pragma: no cover
+        self.direction = Direction.OUTBOUND if val else Direction.INBOUND
 
     @property
     def layer(self) -> Layer:
@@ -339,21 +339,21 @@ class Packet:
 
     @layer.setter
     def layer(self, val: Layer) -> None:
-        self._layer = val  # pragma: no cover
-        self._wd_addr.Layer = val  # pragma: no cover
+        self._layer = val
+        self._wd_addr.Layer = val
         # Clear union when layer changes
-        import ctypes  # pragma: no cover
+        import ctypes
 
-        ctypes.memset(ctypes.byref(self._wd_addr.u), 0, ctypes.sizeof(self._wd_addr.u))  # pragma: no cover
+        ctypes.memset(ctypes.byref(self._wd_addr.u), 0, ctypes.sizeof(self._wd_addr.u))
         # Sync back the relevant fields for the new layer
-        if val in (Layer.NETWORK, Layer.NETWORK_FORWARD):  # pragma: no cover
-            self._wd_addr.u.Network.IfIdx, self._wd_addr.u.Network.SubIfIdx = self._interface  # pragma: no cover
-        elif val == Layer.FLOW and self._flow:  # pragma: no cover
-            self._wd_addr.u.Flow = self._flow  # pragma: no cover
-        elif val == Layer.SOCKET and self._socket:  # pragma: no cover
-            self._wd_addr.u.Socket = self._socket  # pragma: no cover
-        elif val == Layer.REFLECT and self._reflect:  # pragma: no cover
-            self._wd_addr.u.Reflect = self._reflect  # pragma: no cover
+        if val in (Layer.NETWORK, Layer.NETWORK_FORWARD):
+            self._wd_addr.u.Network.IfIdx, self._wd_addr.u.Network.SubIfIdx = self._interface
+        elif val == Layer.FLOW and self._flow:
+            self._wd_addr.u.Flow = self._flow
+        elif val == Layer.SOCKET and self._socket:
+            self._wd_addr.u.Socket = self._socket
+        elif val == Layer.REFLECT and self._reflect:
+            self._wd_addr.u.Reflect = self._reflect
 
     @property
     def event(self) -> Any:

--- a/pydivert/tests/test_packet.py
+++ b/pydivert/tests/test_packet.py
@@ -175,6 +175,71 @@ def test_metadata():
     assert p.interface == (1, 2)
 
 
+def test_direction_and_layer_properties():
+    from pydivert.consts import Layer
+    p = pydivert.Packet(b"test", (1, 2), Direction.OUTBOUND)
+
+    # Test direction
+    assert p.direction == Direction.OUTBOUND
+    assert not p.is_inbound
+    assert p.is_outbound
+
+    p.direction = Direction.INBOUND
+    assert p.direction == Direction.INBOUND
+    assert p.is_inbound
+    assert not p.is_outbound
+    assert p.wd_addr.Outbound == 0
+
+    p.direction = Direction.OUTBOUND
+    assert p.direction == Direction.OUTBOUND
+    assert not p.is_inbound
+    assert p.is_outbound
+    assert p.wd_addr.Outbound == 1
+
+    p.is_inbound = True
+    assert p.direction == Direction.INBOUND
+    assert p.wd_addr.Outbound == 0
+
+    p.is_outbound = True
+    assert p.direction == Direction.OUTBOUND
+    assert p.wd_addr.Outbound == 1
+
+    # Test layer
+    assert p.layer == Layer.NETWORK
+
+    p.layer = Layer.NETWORK_FORWARD
+    assert p.layer == Layer.NETWORK_FORWARD
+    assert p.wd_addr.Layer == Layer.NETWORK_FORWARD
+    assert p.wd_addr.u.Network.IfIdx == 1
+    assert p.wd_addr.u.Network.SubIfIdx == 2
+
+    from pydivert.windivert_dll.structs import WinDivertAddress
+
+    flow_obj = WinDivertAddress._Union._Flow()
+    flow_obj.ProcessId = 123
+    p._flow = flow_obj
+    p.layer = Layer.FLOW
+    assert p.layer == Layer.FLOW
+    assert p.wd_addr.Layer == Layer.FLOW
+    assert p.wd_addr.u.Flow.ProcessId == 123
+
+    socket_obj = WinDivertAddress._Union._Socket()
+    socket_obj.ProcessId = 456
+    p._socket = socket_obj
+    p.layer = Layer.SOCKET
+    assert p.layer == Layer.SOCKET
+    assert p.wd_addr.Layer == Layer.SOCKET
+    assert p.wd_addr.u.Socket.ProcessId == 456
+
+    reflect_obj = WinDivertAddress._Union._Reflect()
+    reflect_obj.ProcessId = 789
+    p._reflect = reflect_obj
+    p.layer = Layer.REFLECT
+    assert p.layer == Layer.REFLECT
+    assert p.wd_addr.Layer == Layer.REFLECT
+    assert p.wd_addr.u.Reflect.ProcessId == 789
+
+
 # --- Hypothesis ---
 
 

--- a/pydivert/tests/test_packet.py
+++ b/pydivert/tests/test_packet.py
@@ -177,6 +177,7 @@ def test_metadata():
 
 def test_direction_and_layer_properties():
     from pydivert.consts import Layer
+
     p = pydivert.Packet(b"test", (1, 2), Direction.OUTBOUND)
 
     # Test direction

--- a/pydivert/tests/test_packet.py
+++ b/pydivert/tests/test_packet.py
@@ -240,6 +240,47 @@ def test_direction_and_layer_properties():
     assert p.wd_addr.Layer == Layer.REFLECT
     assert p.wd_addr.u.Reflect.ProcessId == 789
 
+    p.impostor = True
+    assert p.is_impostor
+    assert p.impostor
+    assert p.wd_addr.Impostor == 1
+
+    p.sniffed = True
+    assert p.is_sniffed
+    assert p.sniffed
+    assert p.wd_addr.Sniffed == 1
+
+    p.loopback = True
+    assert p.is_loopback
+    assert p.loopback
+    assert p.wd_addr.Loopback == 1
+
+    p.timestamp = 12345
+    assert p.timestamp == 12345
+    assert p.wd_addr.Timestamp == 12345
+
+    p.event = 10
+    assert p.event == 10
+    assert p.wd_addr.Event == 10
+
+    p.icmp_checksum = True
+    assert p._icmp_checksum is True
+
+    p.layer = Layer.FLOW
+    p.flow = flow_obj
+    assert p.flow is flow_obj
+    assert p.wd_addr.u.Flow.ProcessId == 123
+
+    p.layer = Layer.SOCKET
+    p.socket = socket_obj
+    assert p.socket is socket_obj
+    assert p.wd_addr.u.Socket.ProcessId == 456
+
+    p.layer = Layer.REFLECT
+    p.reflect = reflect_obj
+    assert p.reflect is reflect_obj
+    assert p.wd_addr.u.Reflect.ProcessId == 789
+
 
 # --- Hypothesis ---
 


### PR DESCRIPTION
🎯 **What:** This PR addresses the missing test coverage for `direction`, `layer`, `is_inbound`, and `is_outbound` setter properties in the `Packet` class (specifically around setting internal state and updating `wd_addr`).

📊 **Coverage:** The tests now fully verify setting and asserting values for direction changes, layer switching, and updating corresponding layers (like Flow, Socket, Reflect) into the WinDivert union address fields.

✨ **Result:** A significant improvement in coverage, as multiple missing test cases are added and previous `# pragma: no cover` markings are removed.

---
*PR created automatically by Jules for task [916710541092453952](https://jules.google.com/task/916710541092453952) started by @ffalcinelli*