### PR TITLE
🧪 Add test for EBPFDivert.check_filter with valid transpile

### DIFF
--- a/pydivert/tests/test_coverage_complete.py
+++ b/pydivert/tests/test_coverage_complete.py
@@ -406,6 +406,13 @@ def test_ebpf_check_filter_fail():
         assert res is False
 
 
+def test_ebpf_check_filter_success():
+    res, pos, msg = pydivert.ebpf.EBPFDivert.check_filter("true")
+    assert res is True
+    assert pos == 0
+    assert msg == ""
+
+
 # windivert.py tests
 def test_windivert_not_nt():
     with patch("os.name", "posix"):


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the missing test for the happy path of `EBPFDivert.check_filter`.

📊 **Coverage:** The scenario where a valid filter string is provided (e.g., `'true'`) is now tested.

✨ **Result:** Test coverage for `EBPFDivert.check_filter` is increased, ensuring it successfully returns `(True, 0, "")` when a valid filter string is provided.

---
*PR created automatically by Jules for task [7273044260763559323](https://jules.google.com/task/7273044260763559323) started by @ffalcinelli*