### PR TITLE
🔒 Fix unrestricted attribute access in JIT SafeEvaluator

### DIFF
--- a/pydivert/jit.py
+++ b/pydivert/jit.py
@@ -115,6 +115,8 @@ class SafeEvaluator(ast.NodeVisitor):
             return self.visit(node.orelse)
 
     def visit_Attribute(self, node):
+        if node.attr.startswith("_"):
+            raise ValueError(f"Access to private attribute '{node.attr}' is not allowed")
         value = self.visit(node.value)
         if value is None:
             return None

--- a/pydivert/tests/test_coverage_complete.py
+++ b/pydivert/tests/test_coverage_complete.py
@@ -346,6 +346,22 @@ def test_jit_safe_evaluator_attribute_private_access():
     with pytest.raises(ValueError, match="Access to private attribute '_private' is not allowed"):
         e.visit(ast.parse("packet._private", mode="eval").body)
 
+    # Test coverage for lines 120-126
+    class MockObj:
+        def __init__(self):
+            self.attr = "value"
+    e = pydivert.jit.SafeEvaluator(MockObj())
+
+    # Test valid attribute access
+    assert e.visit(ast.parse("packet.attr", mode="eval").body) == "value"
+
+    # Test attribute not found
+    assert e.visit(ast.parse("packet.nonexistent", mode="eval").body) is None
+
+    # Test value is None
+    e = pydivert.jit.SafeEvaluator(None)
+    assert e.visit(ast.parse("packet.attr", mode="eval").body) is None
+
 
 # service.py tests
 def test_service_no_advapi():

--- a/pydivert/tests/test_coverage_complete.py
+++ b/pydivert/tests/test_coverage_complete.py
@@ -350,6 +350,7 @@ def test_jit_safe_evaluator_attribute_private_access():
     class MockObj:
         def __init__(self):
             self.attr = "value"
+
     e = pydivert.jit.SafeEvaluator(MockObj())
 
     # Test valid attribute access

--- a/pydivert/tests/test_coverage_complete.py
+++ b/pydivert/tests/test_coverage_complete.py
@@ -341,6 +341,12 @@ def test_jit_safe_evaluator_unsupported():
         e.visit(ast.Dict(keys=[], values=[]))
 
 
+def test_jit_safe_evaluator_attribute_private_access():
+    e = pydivert.jit.SafeEvaluator(None)
+    with pytest.raises(ValueError, match="Access to private attribute '_private' is not allowed"):
+        e.visit(ast.parse("packet._private", mode="eval").body)
+
+
 # service.py tests
 def test_service_no_advapi():
     with patch("pydivert.service._get_advapi32", return_value=None):


### PR DESCRIPTION
🎯 **What:** Fixed an Unrestricted Attribute Access vulnerability in `pydivert/jit.py`'s `SafeEvaluator`.
⚠️ **Risk:** By allowing evaluation of private attributes on objects passed to the evaluator, an attacker could potentially access restricted data or execute arbitrary code.
🛡️ **Solution:** Modified `visit_Attribute` in `SafeEvaluator` to raise a `ValueError` if the attribute string starts with an underscore (`_`), thus blocking private attribute access. Also added a corresponding test case `test_jit_safe_evaluator_attribute_private_access`.

---
*PR created automatically by Jules for task [5174510716278597632](https://jules.google.com/task/5174510716278597632) started by @ffalcinelli*